### PR TITLE
cnet-2: modified gitignore to inlcude cmake & exclude fortran configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@
 *.dylib
 *.dll
 
-# Fortran module files
-*.mod
-*.smod
-
 # Compiled Static libraries
 *.lai
 *.la
@@ -30,3 +26,16 @@
 *.exe
 *.out
 *.app
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps


### PR DESCRIPTION
for more details see CNET-2 on Jira