### PR TITLE
Make ip in YieldNInstruction used as the start for ip_p

### DIFF
--- a/src/tasm/tasm.h
+++ b/src/tasm/tasm.h
@@ -85,7 +85,7 @@ private:
 
     instruction YieldInstructionNChannel(const std::vector<uint8_t> program) {
         return [=](VStream& data, std::size_t ip) {
-            std::size_t ip_p = 0;
+            std::size_t ip_p = ip;
             uint8_t op;
 
             do {


### PR DESCRIPTION
In some revision of the TASM class, it seems that `ip` became an unused parameter in YieldNInstruction but it should have stayed the start parameter for `ip_p`