### PR TITLE
120 Implement Chain::IsValidDistance

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -6,9 +6,9 @@
 #include <vector>
 
 #include "block.h"
+#include "consensus.h"
 #include "params.h"
 #include "uint256.h"
-#include "consensus.h"
 
 class Chain {
 public:
@@ -52,6 +52,8 @@ public:
     const std::deque<ChainStatePtr>& GetStates() const {
         return states_; 
     }
+
+    static bool IsValidDistance(const RecordPtr, const arith_uint256);
 
 private:
     // 1 if this chain is main chain, 0 otherwise;

--- a/src/consensus.h
+++ b/src/consensus.h
@@ -73,11 +73,13 @@ public:
     }
 
     bool operator==(const ChainState& rhs) const {
+        // clang-format off
         return lastUpdateTime               == rhs.lastUpdateTime &&
                chainwork.GetCompact()       == rhs.chainwork.GetCompact() &&
                hashRate                     == rhs.hashRate &&
                milestoneTarget.GetCompact() == rhs.milestoneTarget.GetCompact() &&
                blockTarget.GetCompact()     == rhs.blockTarget.GetCompact();
+        // clang-format on
     }
 
     bool operator!=(const ChainState& another) const {
@@ -143,6 +145,10 @@ public:
         return std::tie(*cblock, cumulativeReward, minerChainHeight) ==
                    std::tie(*(another.cblock), another.cumulativeReward, another.minerChainHeight) &&
                ((snapshot == nullptr || another.snapshot == nullptr) ? true : *snapshot == *(another.snapshot));
+    }
+
+    bool operator!=(const NodeRecord& another) const {
+        return !(*this == another);
     }
 
     static NodeRecord CreateGenesisRecord();

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -10,15 +10,17 @@ const Params& TestNetParams::GetParams() {
 }
 
 TestNetParams::TestNetParams() {
-    targetTimespan   = 100;
-    timeInterval     = TIME_INTERVAL;
-    interval         = targetTimespan / (double) timeInterval;
-    targetTPS        = 100;
-    punctualityThred = PUNTUALITY_THRESHOLD;
-    maxTarget        = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
-    maxMoney         = MAX_MONEY;
-    reward           = 1;
-    initialMsTarget  = arith_uint256(INITIAL_MS_TARGET);
+    targetTimespan       = 100;
+    timeInterval         = TIME_INTERVAL;
+    interval             = targetTimespan / (double) timeInterval;
+    targetTPS            = 100;
+    punctualityThred     = PUNTUALITY_THRESHOLD;
+    maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
+    maxMoney             = MAX_MONEY;
+    reward               = 1;
+    initialMsTarget      = arith_uint256(INITIAL_MS_TARGET);
+    sortitionCoefficient = arith_uint256(SORTITION_COEFFICIENT);
+    sortitionThreshold   = SORTITION_THRESHOLD;
 
     keyPrefixes = {
         0,  // keyPrefixes[PUBKEY_ADDRESS]

--- a/src/params.h
+++ b/src/params.h
@@ -18,10 +18,6 @@ static constexpr uint32_t INTERVAL      = TARGET_TIMESPAN / TIME_INTERVAL;
 static constexpr uint32_t TPS = 1000;
 // threshold for rejecting an old block
 static constexpr uint32_t PUNTUALITY_THRESHOLD = 2 * 60 * 60;
-// transaction sortition: number of block to go back
-static constexpr uint32_t SORTITION_THRESHOLD = 10 * 1000;
-// transaction sortition: coefficient for computing allowed distance
-static constexpr double SORTITION_COEFFICIENT = 0.01;
 // maximum time in a block header allowed to be in advanced to the current time (sec)
 static constexpr uint32_t ALLOWED_TIME_DRIFT = 1;
 // max amount of money allowed in one output
@@ -32,7 +28,10 @@ static constexpr uint32_t GENESIS_BLOCK_VERSION = 1;
 static constexpr uint32_t MAX_BLOCK_SIZE = 20 * 1000;
 // an easy enough difficulty target
 static constexpr uint32_t EASIEST_COMP_DIFF_TARGET = 0x2100ffffL;
-// initial difficulty target
+// transaction sortition: coefficient for computing allowed distance
+static constexpr size_t SORTITION_COEFFICIENT = 100;
+// transaction sortition: number of block to go back
+static constexpr size_t SORTITION_THRESHOLD = 10 * 1000;
 
 class Params {
 public:
@@ -54,6 +53,9 @@ public:
     arith_uint256 maxTarget;
     Coin maxMoney;
     Coin reward;
+
+    arith_uint256 sortitionCoefficient;
+    size_t sortitionThreshold;
 
     uint64_t initialDifficulty;
     arith_uint256 initialMsTarget;

--- a/test/core/test_consensus.cpp
+++ b/test/core/test_consensus.cpp
@@ -20,7 +20,8 @@ TEST_F(TestConsensus, SyntaxChecking) {
     EXPECT_TRUE(b.Verify());
 
     // Create a random block with bad difficulty target
-    BlockNet block = BlockNet(1, fac.CreateRandomHash(), fac.CreateRandomHash(), fac.CreateRandomHash(), time(nullptr), 1, 1);
+    BlockNet block =
+        BlockNet(1, fac.CreateRandomHash(), fac.CreateRandomHash(), fac.CreateRandomHash(), time(nullptr), 1, 1);
     EXPECT_FALSE(block.Verify());
 }
 
@@ -65,7 +66,7 @@ TEST_F(TestConsensus, BlockNetOptimalEncodingSize) {
 }
 
 TEST_F(TestConsensus, UTXO) {
-    BlockNet b  =  fac.CreateBlockNet(1, 67);
+    BlockNet b  = fac.CreateBlockNet(1, 67);
     UTXO utxo   = UTXO(b.GetTransaction()->GetOutputs()[66], 66);
     uint256 key = utxo.GetKey();
 
@@ -81,7 +82,7 @@ TEST_F(TestConsensus, MilestoneDifficultyUpdate) {
 
     size_t LOOPS = 100;
     for (size_t i = 1; i < LOOPS; i++) {
-        arrayMs[i] = fac.CreateChainStatePtr(arrayMs[i-1]);
+        arrayMs[i] = fac.CreateChainStatePtr(arrayMs[i - 1]);
         ASSERT_EQ(i, arrayMs[i]->height);
 
         if (((i + 1) % params.timeInterval) == 0) {
@@ -150,10 +151,11 @@ TEST_F(TestConsensus, AddNewBlocks) {
 
             CKey seckey = CKey();
             seckey.MakeNewKey(true);
-            CPubKey pubkey = seckey.GetPubKey();
+            CPubKey pubkey     = seckey.GetPubKey();
             uint160 pubkeyHash = Hash160<1>(pubkey.begin(), pubkey.end());
             VStream v(pubkeyHash);
-            tx.AddOutput(TxOutput(ZERO_COIN, Tasm::Listing(v))); b.AddTransaction(tx);
+            tx.AddOutput(TxOutput(ZERO_COIN, Tasm::Listing(v)));
+            b.AddTransaction(tx);
         }
         b.Solve();
 

--- a/test/core/test_validation.cpp
+++ b/test/core/test_validation.cpp
@@ -1,0 +1,103 @@
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "caterpillar.h"
+#include "chain.h"
+#include "test_factory.h"
+
+static std::string prefix = "test_validation/";
+
+class TestValidation : public testing::Test {
+public:
+    TestFactory fac;
+
+    static void SetUpTestCase() {
+        std::ostringstream os;
+        os << time(nullptr);
+        std::string filename = prefix + os.str();
+        CAT                  = std::make_unique<Caterpillar>(filename);
+    }
+
+    static void TearDownTestCase() {
+        std::string cmd = "exec rm -r " + prefix;
+        system(cmd.c_str());
+        CAT.reset();
+    }
+};
+
+TEST_F(TestValidation, ValidDistanceNormalChain) {
+    auto genesisPtr = std::make_shared<BlockNet>(GENESIS);
+
+    BlockNet registration = fac.CreateBlockNet(1, 1);
+    registration.SetMilestoneHash(GENESIS.GetHash());
+    registration.SetPrevHash(genesisPtr->GetHash());
+    registration.SetTipHash(genesisPtr->GetHash());
+    registration.SetDifficultyTarget(GENESIS_RECORD.snapshot->blockTarget.GetCompact());
+    registration.SetTime(1);
+
+    auto registrationPtr      = std::make_shared<BlockNet>(registration);
+    NodeRecord registrationNR = NodeRecord(registrationPtr);
+    RecordPtr registrationR   = std::make_shared<NodeRecord>(registrationNR);
+
+
+    BlockNet goodBlock = fac.CreateBlockNet(170, 170);
+    goodBlock.SetMilestoneHash(GENESIS.GetHash());
+    goodBlock.SetPrevHash(registrationPtr->GetHash());
+    goodBlock.SetTipHash(registrationPtr->GetHash());
+    goodBlock.SetDifficultyTarget(GENESIS_RECORD.snapshot->blockTarget.GetCompact());
+
+    auto goodBlockPtr      = std::make_shared<BlockNet>(goodBlock);
+    NodeRecord goodBlockNR = NodeRecord(goodBlockPtr);
+    RecordPtr goodBlockR   = std::make_shared<NodeRecord>(goodBlockNR);
+
+    CAT->StoreRecord(std::make_shared<NodeRecord>(GENESIS_RECORD));
+    CAT->StoreRecord(registrationR);
+    CAT->StoreRecord(goodBlockR);
+
+    arith_uint256 ms_hashrate = 1;
+    EXPECT_TRUE(Chain::IsValidDistance(goodBlockR, ms_hashrate));
+}
+
+TEST_F(TestValidation, ValidDistanceMaliciousChain) {
+    auto genesisPtr = std::make_shared<BlockNet>(GENESIS);
+
+    BlockNet registration = fac.CreateBlockNet(1, 1);
+    registration.SetMilestoneHash(GENESIS.GetHash());
+    registration.SetPrevHash(genesisPtr->GetHash());
+    registration.SetTipHash(genesisPtr->GetHash());
+    registration.SetDifficultyTarget(GENESIS_RECORD.snapshot->blockTarget.GetCompact());
+    registration.SetTime(666);
+
+    auto registrationPtr      = std::make_shared<BlockNet>(registration);
+    NodeRecord registrationNR = NodeRecord(registrationPtr);
+    RecordPtr registrationR   = std::make_shared<NodeRecord>(registrationNR);
+
+    BlockNet goodBlock = fac.CreateBlockNet(170, 170);
+    goodBlock.SetMilestoneHash(GENESIS.GetHash());
+    goodBlock.SetPrevHash(registrationPtr->GetHash());
+    goodBlock.SetTipHash(registrationPtr->GetHash());
+    goodBlock.SetDifficultyTarget(GENESIS_RECORD.snapshot->blockTarget.GetCompact());
+
+    auto goodBlockPtr      = std::make_shared<BlockNet>(goodBlock);
+    NodeRecord goodBlockNR = NodeRecord(goodBlockPtr);
+    RecordPtr goodBlockR   = std::make_shared<NodeRecord>(goodBlockNR);
+
+    BlockNet badBlock = fac.CreateBlockNet(2, 2);
+    badBlock.SetMilestoneHash(GENESIS.GetHash());
+    badBlock.SetPrevHash(goodBlockPtr->GetHash());
+    badBlock.SetTipHash(goodBlockPtr->GetHash());
+    badBlock.SetDifficultyTarget(GENESIS_RECORD.snapshot->blockTarget.GetCompact());
+
+    auto badBlockPtr      = std::make_shared<BlockNet>(badBlock);
+    NodeRecord badBlockNR = NodeRecord(goodBlockPtr);
+    RecordPtr badBlockR   = std::make_shared<NodeRecord>(badBlockNR);
+
+    CAT->StoreRecord(std::make_shared<NodeRecord>(GENESIS_RECORD));
+    CAT->StoreRecord(registrationR);
+    CAT->StoreRecord(goodBlockR);
+    CAT->StoreRecord(badBlockR);
+
+    arith_uint256 ms_hashrate = 9999;
+    EXPECT_FALSE(Chain::IsValidDistance(badBlockR, ms_hashrate));
+}

--- a/test/support/test_threadpool.cpp
+++ b/test/support/test_threadpool.cpp
@@ -32,8 +32,7 @@ public:
         int value;
 
     public:
-        Bar(int value_) : value(value_) {
-        }
+        Bar(int value_) : value(value_) {}
         int f4() {
             return value;
         }


### PR DESCRIPTION
Add spdlog::shutdown to Init::ShutDown to be able to do multiple Init-Shutdown
pairs in epictest. Adjust tests accordingly.
Modify params.h for transaction sortition.
Some auto code changes from clang format.
Implement IsValidDistance and corresponding tests.
The reason behind the second argument in IsValidDistance ms_hashrate
is that there's no straightforward way to calculate ms_hashrate in
the function body cause there's no Milestone with its hashrate
accessible from the first argument type anymore.
Probably it will be changed later.