### PR TITLE
Replace raw pointer with shared_ptr for Peer in PeerManager

### DIFF
--- a/src/caterpillar.cpp
+++ b/src/caterpillar.cpp
@@ -14,7 +14,7 @@ bool Caterpillar::StoreRecord(const RecordPtr& rec) const {
     return dbStore_.WriteRecord(rec);
 }
 
-bool Caterpillar::AddNewBlock(const ConstBlockPtr& blk, const Peer* peer) {
+bool Caterpillar::AddNewBlock(const ConstBlockPtr& blk, std::shared_ptr<Peer> peer) {
     // clang-format off
     return verifyThread_.Submit([&blk, peer, this]() {
         if (*blk == GENESIS) {

--- a/src/caterpillar.h
+++ b/src/caterpillar.h
@@ -34,7 +34,7 @@ public:
      * If the block passes the checking, add them to pendings in dag_manager.
      * Returns true only if the new block is successfully submitted to pendings.
      */
-    bool AddNewBlock(const ConstBlockPtr& block, const Peer* peer);
+    bool AddNewBlock(const ConstBlockPtr& block, std::shared_ptr<Peer> peer);
 
     /*
      * Blocks the main thread from going forward

--- a/src/dag_manager.cpp
+++ b/src/dag_manager.cpp
@@ -1,11 +1,11 @@
 #include "dag_manager.h"
 
 DAGManager::DAGManager() {
-    syncingPeer = nullptr;
+    syncingPeer     = nullptr;
     isBatchSynching = false;
 }
 
-void DAGManager::RequestInv(const uint256&, const size_t&, const Peer*) {}
+void DAGManager::RequestInv(const uint256&, const size_t&, std::shared_ptr<Peer> peer) {}
 
 void DAGManager::AddBlockToPending(const ConstBlockPtr& block) {
     // TODO: For test only!

--- a/src/net/peer.h
+++ b/src/net/peer.h
@@ -62,11 +62,11 @@ public:
 
     const std::atomic_uint64_t& GetLastPingTime() const;
 
-    void SetLastPingTime(const uint64_t lastPingTime_);
+    void SetLastPingTime(uint64_t lastPingTime_);
 
     const std::atomic_uint64_t& GetLastPongTime() const;
 
-    void SetLastPongTime(const uint64_t lastPongTime_);
+    void SetLastPongTime(uint64_t lastPongTime_);
 
     size_t GetNPingFailed() const;
 

--- a/src/net/peer_manager.h
+++ b/src/net/peer_manager.h
@@ -3,6 +3,7 @@
 
 #include <ctime>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -107,13 +108,13 @@ private:
      * @param inbound
      * @return
      */
-    Peer* CreatePeer(void* connection_handle, NetAddress& address, bool inbound);
+    std::shared_ptr<Peer> CreatePeer(void* connection_handle, NetAddress& address, bool inbound);
 
     /*
      * release resources of a peer and then delete it
      * @param peer
      */
-    void DeletePeer(Peer* peer);
+    void DeletePeer(const std::shared_ptr<Peer>& peer);
 
     /*
      * check if we have connected to the ip address
@@ -126,14 +127,14 @@ private:
      * @param connection_handle
      * @return
      */
-    Peer* GetPeer(const void* connection_handle);
+    std::shared_ptr<Peer> GetPeer(const void* connection_handle);
 
     /**
      * add a peer into peer map
      * @param handle
      * @param peer
      */
-    void AddPeer(const void* handle, Peer* peer);
+    void AddPeer(const void* handle, const std::shared_ptr<Peer>& peer);
 
     /**
      * add a connected address
@@ -201,17 +202,17 @@ private:
      */
 
     // last time of sending local address
-    long lastSendLocalAddressTime;
+    long lastSendLocalAddressTime{0};
 
     /*
      * internal data structures
      */
 
     // peers' lock
-    std::mutex peerLock_;
+    std::recursive_mutex peerLock_;
 
     // a map to save all peers
-    std::unordered_map<const void*, Peer*> peerMap_;
+    std::unordered_map<const void*, std::shared_ptr<Peer>> peerMap_;
 
     // a map to save pending peers
     std::unordered_map<IPAddress, uint64_t> pending_peers;

--- a/test/net/test_peer_manager.cpp
+++ b/test/net/test_peer_manager.cpp
@@ -33,7 +33,7 @@ public:
 TEST_F(TestPeerManager, CallBack) {
     EXPECT_TRUE(server.Bind("127.0.0.1:7877"));
     EXPECT_TRUE(client.ConnectTo("127.0.0.1:7877"));
-    sleep(2);
+    usleep(50000);
     EXPECT_EQ(server.GetFullyConnectedPeerSize(), 1);
     EXPECT_EQ(client.GetFullyConnectedPeerSize(), 1);
 }
@@ -41,12 +41,12 @@ TEST_F(TestPeerManager, CallBack) {
 TEST_F(TestPeerManager, CheckHaveConnectedSameIP) {
     EXPECT_TRUE(server.Bind("127.0.0.1:7877"));
     EXPECT_TRUE(client.ConnectTo("127.0.0.1:7877"));
-    sleep(1);
+    usleep(50000);
 
     PeerManager same_ip_client;
     same_ip_client.Start();
     same_ip_client.ConnectTo("127.0.0.1:7877");
-    sleep(2);
+    usleep(50000);
     EXPECT_EQ(server.GetFullyConnectedPeerSize(), 1);
     EXPECT_EQ(same_ip_client.GetConnectedPeerSize(), 0);
     same_ip_client.Stop();


### PR DESCRIPTION
In order to keep the Peer* valid which is in the thread of DAG/CAT when the PeerManager has deleted the Peer*, using shared_ptr to record the reference of Peer and release it automatically when the reference is 0