### PR TITLE
Implement dummy RPC server and client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include_directories(src
         )
 
 set(SRC_CODE
-        ${RPC_DIR}
+        ${RPC_SRCS}
         ${PROTO_SRCS}
         ${GRPC_SRCS}
         ${NET_SRCS}
@@ -112,6 +112,7 @@ set(SRC_MAIN src/main.cpp)
 # test codes
 set(TEST_METHODS_SRCS test/test-methods)
 
+aux_source_directory(test/rpc TEST_RPC_SRCS)
 aux_source_directory(test/net TEST_NET_SRCS)
 aux_source_directory(test/utils TEST_UTILS_SRCS)
 aux_source_directory(test/tasm TEST_TASM_SRCS)
@@ -125,6 +126,7 @@ include_directories(test
     )
 
 set(TEST_CODE
+        ${TEST_RPC_SRCS}
         ${TEST_NET_SRCS}
         ${TEST_UTILS_SRCS}
         ${TEST_TASM_SRCS}

--- a/config.toml
+++ b/config.toml
@@ -24,3 +24,6 @@ port = 7877
 
 [db]
 path = "db/"
+
+[rpc]
+port = 3777

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -8,7 +8,7 @@ message Block {
   Hash milestoneBlockHash = 3;
   Hash prevBlockHash = 4;
   Hash tipBlockHash = 5;
-  Hash diffTarget = 6;
+  uint32 diffTarget = 6;
   uint32 nonce = 7;
   uint64 time = 8;
   Transaction transactions = 9;

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -15,7 +15,7 @@
 //#include <byteswap.h>
 //#endif
 
-#if defined(MAC_OSX)
+#if defined(__APPLE__)
 
 #if !defined(bswap_16)
 

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,9 @@ public:
     // default bind port
     static const uint16_t defaultPort = 7877;
 
+    // default rpc port
+    static const uint16_t defaultRPCPort = 3777;
+
     const std::string& GetConfigFilePath() const {
         return configFilePath_;
     }
@@ -129,6 +132,22 @@ public:
         return seeds_.size();
     }
 
+    void SetDisableRPC(bool flag) {
+        disableRPC_ = flag;
+    }
+
+    bool GetDisableRPC() const {
+        return disableRPC_;
+    }
+
+    void SetRPCPort(uint16_t port) {
+        rpcPort_ = port;
+    }
+
+    uint16_t GetRPCPort() const {
+        return rpcPort_;
+    }
+
     void ShowConfig() {
         std::stringstream ss;
         ss << "current config: " << std::endl;
@@ -140,6 +159,8 @@ public:
         ss << "bind ip = " << bindAddress_ << std::endl;
         ss << "bind port = " << bindPort_ << std::endl;
         ss << "dbpath = " << GetDBPath() << std::endl;
+        ss << "disable rpc = " << (disableRPC_ ? "yes" : "no") << std::endl;
+        ss << "rpc port = " << rpcPort_ << std::endl;
         ss << "seeds = [" << std::endl;
 
         for (const NetAddress& addr : seeds_) {
@@ -157,6 +178,7 @@ public:
     const std::string& GetConnect() const {
         return connect_;
     }
+
 private:
     // config file
     std::string configFilePath_;
@@ -181,6 +203,10 @@ private:
     // db
     std::string dbPath_ = "db/";
     std::string connect_;
+
+    // rpc
+    bool disableRPC_;
+    uint16_t rpcPort_ = defaultRPCPort;
 };
 
 extern std::unique_ptr<Config> config;

--- a/src/rpc/rpc_client.cpp
+++ b/src/rpc/rpc_client.cpp
@@ -1,0 +1,50 @@
+#include <rpc_client.h>
+
+RPCClient::RPCClient(std::shared_ptr<grpc::Channel> channel) : stub_(BasicBlockExplorerRPC::NewStub(channel)) {}
+
+rpc::Block RPCClient::GetBlock(const uint256& block_hash) {
+    GetBlockRequest request;
+    rpc::Hash* h = HashToRPCHash(block_hash);
+    request.set_allocated_hash(h);
+
+    GetBlockResponse reply;
+    grpc::ClientContext context;
+    grpc::Status status = stub_->GetBlock(&context, request, &reply);
+
+    if (!status.ok()) {
+        spdlog::info("No response from RPC server");
+    }
+    return reply.block();
+}
+
+int RPCClient::GetLevelSet() {
+    GetLevelSetRequest request;
+    GetLevelSetResponse reply;
+    grpc::ClientContext context;
+    grpc::Status status = stub_->GetLevelSet(&context, request, &reply);
+    return status.ok();
+}
+
+int RPCClient::GetLevelSetSize() {
+    GetLevelSetSizeRequest request;
+    GetLevelSetSizeResponse reply;
+    grpc::ClientContext context;
+    grpc::Status status = stub_->GetLevelSetSize(&context, request, &reply);
+    return status.ok();
+}
+
+int RPCClient::GetNewMilestoneSince() {
+    GetNewMilestoneSinceRequest request;
+    GetNewMilestoneSinceResponse reply;
+    grpc::ClientContext context;
+    grpc::Status status = stub_->GetNewMilestoneSince(&context, request, &reply);
+    return status.ok();
+}
+
+int RPCClient::GetLatestMilestone() {
+    GetLatestMilestoneRequest request;
+    GetLatestMilestoneResponse reply;
+    grpc::ClientContext context;
+    grpc::Status status = stub_->GetLatestMilestone(&context, request, &reply);
+    return status.ok();
+}

--- a/src/rpc/rpc_client.h
+++ b/src/rpc/rpc_client.h
@@ -1,0 +1,42 @@
+#ifndef __SRC_RPCCLIENT_H__
+#define __SRC_RPCCLIENT_H__
+
+#include <grpc++/grpc++.h>
+#include <rpc.grpc.pb.h>
+#include <rpc.pb.h>
+#include <rpc_tools.h>
+
+#include "block.h"
+#include "net_address.h"
+
+using rpc::BasicBlockExplorerRPC;
+using rpc::GetBlockRequest;
+using rpc::GetBlockResponse;
+using rpc::GetLatestMilestoneRequest;
+using rpc::GetLatestMilestoneResponse;
+using rpc::GetLevelSetRequest;
+using rpc::GetLevelSetResponse;
+using rpc::GetLevelSetSizeRequest;
+using rpc::GetLevelSetSizeResponse;
+using rpc::GetNewMilestoneSinceRequest;
+using rpc::GetNewMilestoneSinceResponse;
+
+class RPCClient {
+public:
+    RPCClient(std::shared_ptr<grpc::Channel> channel);
+
+    rpc::Block GetBlock(const uint256&);
+
+    int GetLevelSet();
+
+    int GetLevelSetSize();
+
+    int GetNewMilestoneSince();
+
+    int GetLatestMilestone();
+
+private:
+    std::unique_ptr<BasicBlockExplorerRPC::Stub> stub_;
+};
+
+#endif //__SRC_RPCCLIENT_H__

--- a/src/rpc/rpc_server.cpp
+++ b/src/rpc/rpc_server.cpp
@@ -1,0 +1,63 @@
+#include <rpc_server.h>
+
+grpc::Status BasicBlockExplorerRPCServiceImpl::GetBlock(grpc::ServerContext* context,
+    const GetBlockRequest* request,
+    GetBlockResponse* reply) {
+    if (request->hash().hash() == std::to_string(GENESIS.GetHash())) {
+        rpc::Block* b = BlockToRPCBlock(GENESIS);
+        reply->set_allocated_block(b);
+    }
+    return grpc::Status::OK;
+}
+
+grpc::Status BasicBlockExplorerRPCServiceImpl::GetLevelSet(grpc::ServerContext* context,
+    const GetLevelSetRequest* request,
+    GetLevelSetResponse* reply) {
+    return grpc::Status::OK;
+}
+
+grpc::Status BasicBlockExplorerRPCServiceImpl::GetLevelSetSize(grpc::ServerContext* context,
+    const GetLevelSetSizeRequest* request,
+    GetLevelSetSizeResponse* reply) {
+    return grpc::Status::OK;
+}
+
+grpc::Status BasicBlockExplorerRPCServiceImpl::GetNewMilestoneSince(grpc::ServerContext* context,
+    const GetNewMilestoneSinceRequest* request,
+    GetNewMilestoneSinceResponse* reply) {
+    return grpc::Status::OK;
+}
+
+grpc::Status BasicBlockExplorerRPCServiceImpl::GetLatestMilestone(grpc::ServerContext* context,
+    const GetLatestMilestoneRequest* request,
+    GetLatestMilestoneResponse* reply) {
+    return grpc::Status::OK;
+}
+
+RPCServer::RPCServer(NetAddress adr) {
+    this->server_address_ = adr.ToString();
+}
+
+void RPCServer::Start() {
+    keepRunning_ = true;
+    std::thread t(&RPCServer::LaunchServer, this);
+    t.detach();
+}
+
+void RPCServer::Shutdown() {
+    keepRunning_ = false;
+    spdlog::info("RPC Server is shutting down");
+}
+
+void RPCServer::LaunchServer() {
+    BasicBlockExplorerRPCServiceImpl service;
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(this->server_address_, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service);
+    std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+    spdlog::info("RPC Server is running on {}", this->server_address_);
+    while (keepRunning_) {
+        std::this_thread::yield();
+    }
+    server->Shutdown();
+}

--- a/src/rpc/rpc_server.h
+++ b/src/rpc/rpc_server.h
@@ -1,0 +1,65 @@
+#ifndef __SRC_RPC_SERVER_H__
+#define __SRC_RPC_SERVER_H__
+
+#include <grpc++/grpc++.h>
+#include <rpc.grpc.pb.h>
+#include <rpc.pb.h>
+#include <rpc_tools.h>
+#include <thread>
+
+#include "block.h"
+#include "net_address.h"
+#include "spdlog.h"
+
+using rpc::BasicBlockExplorerRPC;
+using rpc::GetBlockRequest;
+using rpc::GetBlockResponse;
+using rpc::GetLatestMilestoneRequest;
+using rpc::GetLatestMilestoneResponse;
+using rpc::GetLevelSetRequest;
+using rpc::GetLevelSetResponse;
+using rpc::GetLevelSetSizeRequest;
+using rpc::GetLevelSetSizeResponse;
+using rpc::GetNewMilestoneSinceRequest;
+using rpc::GetNewMilestoneSinceResponse;
+
+class BasicBlockExplorerRPCServiceImpl final : public BasicBlockExplorerRPC::Service {
+    grpc::Status GetBlock(grpc::ServerContext* context,
+        const GetBlockRequest* request,
+        GetBlockResponse* reply) override;
+
+    grpc::Status GetLevelSet(grpc::ServerContext* context,
+        const GetLevelSetRequest* request,
+        GetLevelSetResponse* reply) override;
+
+    grpc::Status GetLevelSetSize(grpc::ServerContext* context,
+        const GetLevelSetSizeRequest* request,
+        GetLevelSetSizeResponse* reply) override;
+
+    grpc::Status GetNewMilestoneSince(grpc::ServerContext* context,
+        const GetNewMilestoneSinceRequest* request,
+        GetNewMilestoneSinceResponse* reply) override;
+
+    grpc::Status GetLatestMilestone(grpc::ServerContext* context,
+        const GetLatestMilestoneRequest* request,
+        GetLatestMilestoneResponse* reply) override;
+};
+
+class RPCServer {
+public:
+    RPCServer() = delete;
+
+    RPCServer(NetAddress);
+
+    void Start();
+
+    void Shutdown();
+
+private:
+    std::string server_address_;
+    std::atomic<bool> keepRunning_;
+
+    void LaunchServer();
+};
+
+#endif //__SRC_RPC_SERVER_H__

--- a/src/rpc/rpc_tools.cpp
+++ b/src/rpc/rpc_tools.cpp
@@ -1,0 +1,51 @@
+#include <rpc_tools.h>
+
+rpc::Hash* HashToRPCHash(const uint256& h) {
+    rpc::Hash* rpch = new rpc::Hash();
+    rpch->set_hash(std::to_string(h));
+    return rpch;
+}
+
+rpc::Transaction* TxToRPCTx(const Transaction& tx) {
+    // message Transaction
+    rpc::Transaction* rpctx = new rpc::Transaction();
+    //    Hash transaction_hash = 1;
+    auto tx_hash = HashToRPCHash(tx.GetHash());
+    rpctx->set_allocated_transaction_hash(tx_hash);
+    // TODO uint32 fee = 2;
+    // TODO repeated Input inputs = 3;
+    // TODO repeated Output outputs = 4;
+    return rpctx;
+}
+
+rpc::Block* BlockToRPCBlock(const Block& b) {
+    // message Block
+    rpc::Block* rpcb = new rpc::Block();
+    // Hash block_hash = 1;
+    auto block_hash = HashToRPCHash(b.GetHash());
+    rpcb->set_allocated_block_hash(block_hash);
+    // uint32 version = 2;
+    // TODO rpcb.set_version(b.GetVersion());
+    // Hash milestoneBlockHash = 3;
+    auto milestoneBlockHash = HashToRPCHash(b.GetMilestoneHash());
+    rpcb->set_allocated_milestoneblockhash(milestoneBlockHash);
+    // Hash prevBlockHash = 4;
+    auto prevBlockHash = HashToRPCHash(b.GetPrevHash());
+    rpcb->set_allocated_milestoneblockhash(prevBlockHash);
+    // Hash tipBlockHash = 5;
+    auto tipBlockHash = HashToRPCHash(b.GetTipHash());
+    rpcb->set_allocated_tipblockhash(tipBlockHash);
+    // uint32 diffTarget = 6;
+    rpcb->set_difftarget(b.GetDifficultyTarget());
+    // uint32 nonce = 7;
+    rpcb->set_nonce(b.GetNonce());
+    // uint64 time = 8;
+    rpcb->set_time(b.GetTime());
+    // Transaction transactions = 9;
+    auto tx = b.GetTransaction();
+    if (tx) {
+        auto rpctx = TxToRPCTx(*tx);
+        rpcb->set_allocated_transactions(rpctx);
+    }
+    return rpcb;
+}

--- a/src/rpc/rpc_tools.h
+++ b/src/rpc/rpc_tools.h
@@ -1,0 +1,15 @@
+#ifndef __SRC_RPC_TOOLS_H__
+#define __SRC_RPC_TOOLS_H__
+
+#include <grpc++/grpc++.h>
+#include <rpc.grpc.pb.h>
+#include <rpc.pb.h>
+
+#include "block.h"
+#include "net_address.h"
+
+rpc::Hash* HashToRPCHash(const uint256&);
+
+rpc::Block* BlockToRPCBlock(const Block&);
+
+#endif //__SRC_RPC_TOOLS_H__

--- a/test/net/test_netaddress.cpp
+++ b/test/net/test_netaddress.cpp
@@ -2,9 +2,9 @@
 #include <net_address.h>
 
 class TestNetAddress : public testing::Test {
-    public:
-        std::optional<NetAddress> netAddress;
-        std::optional<IPAddress> ipAddress;
+public:
+    std::optional<NetAddress> netAddress;
+    std::optional<IPAddress> ipAddress;
 };
 
 TEST_F(TestNetAddress, IPAddress) {
@@ -25,7 +25,6 @@ TEST_F(TestNetAddress, IPAddress) {
     EXPECT_EQ(ipAddress->ToString(), ip6_2);
 
 
-
     // some wrong ip string
     std::string iperr_1 = "256.1.1.1";
     std::string iperr_2 = "2.a.3.d";
@@ -40,7 +39,6 @@ TEST_F(TestNetAddress, IPAddress) {
     EXPECT_FALSE(IPAddress::GetByIP(iperr_4));
     EXPECT_FALSE(IPAddress::GetByIP(iperr_5));
     EXPECT_FALSE(IPAddress::GetByIP(iperr_6));
-
 }
 
 TEST_F(TestNetAddress, NetAddress) {

--- a/test/rpc/test_server_is_up.cpp
+++ b/test/rpc/test_server_is_up.cpp
@@ -1,0 +1,36 @@
+#include <chrono>
+#include <gtest/gtest.h>
+#include <iostream>
+
+#include "rpc_client.h"
+#include "rpc_server.h"
+
+class TestRPCServer : public testing::Test {};
+
+TEST_F(TestRPCServer, DummyServerResponses) {
+    std::string adr  = "0.0.0.0:3777";
+    auto netAddress  = NetAddress::GetByIP(adr);
+    RPCServer server = RPCServer(*netAddress);
+    server.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    RPCClient client(grpc::CreateChannel(adr, grpc::InsecureChannelCredentials()));
+
+
+    auto genesis_resp = client.GetBlock(GENESIS.GetHash());
+    EXPECT_EQ(genesis_resp.block_hash().hash(), std::to_string(GENESIS.GetHash()));
+
+    EXPECT_TRUE(client.GetLevelSet());
+    EXPECT_TRUE(client.GetLevelSetSize());
+    EXPECT_TRUE(client.GetNewMilestoneSince());
+    EXPECT_TRUE(client.GetLatestMilestone());
+
+    server.Shutdown();
+
+    genesis_resp = client.GetBlock(GENESIS.GetHash());
+    EXPECT_EQ(genesis_resp.block_hash().hash(), "");
+    EXPECT_FALSE(client.GetLevelSet());
+    EXPECT_FALSE(client.GetLevelSetSize());
+    EXPECT_FALSE(client.GetNewMilestoneSince());
+    EXPECT_FALSE(client.GetLatestMilestone());
+}


### PR DESCRIPTION
BasicBlockExplorerRPCServiceImpl implements
BasicBlockExplorerRPC::Service interface which is
generated by grpc protoc plugin.
RPCServer class allows to run and shutdown a grpc server
which serves BasicBlockExplorerRPCServiceImpl.
Currently the server replies Status::OK on every message.
RPCClient initializes a stub and have all current rpc covered.
The client returns a status of a particular call.

Misc:
Fix typo in cmake file
Fix bug in byteswap.h
Add tests for RPC client and server
Add disable-rpc cli option
Add -h/--help cli option
clang-format test_netaddress.cpp