### PR TITLE
Fix the bug in the last commit

### DIFF
--- a/src/support/threadpool.cpp
+++ b/src/support/threadpool.cpp
@@ -67,17 +67,15 @@ bool ThreadPool::IsIdle() const {
 
     if (working_states) {
         for (int i = 0; i < working_states->size(); i++) {
-            if (working_states->at(i)) {
+            if (working_states->at(i).load()) {
                 return false;
             }
         }
     }
 
-    return true;
+    return task_queue_.Empty();
 }
 
 ThreadPool::~ThreadPool() {
-    if (working_states) {
-        delete working_states;
-    }
+    delete working_states;
 }

--- a/test/core/test_synchronization.cpp
+++ b/test/core/test_synchronization.cpp
@@ -73,7 +73,7 @@ TEST_F(TestSync, test_basic_network) {
     ASSERT_TRUE(testPeer->sentMsgBox.Empty());
 }
 
-TEST_F(TestSync, test_version_ack) {
+TEST_F(TestSync, test_basic_sync_workflow) {
     TestPM* testPeerManager = (TestPM*) peerManager.get();
 
     const void* peer_handle = (const void*) 1;
@@ -149,6 +149,7 @@ TEST_F(TestSync, test_version_ack) {
         testPeer->ProcessMessage(bundle_message);
     }
 
+    usleep(50000);
     CAT->Wait();
     DAG->Wait();
 
@@ -166,7 +167,7 @@ TEST_F(TestSync, test_version_ack) {
     NetMessage message_sync_complete_ack(peer_handle, INV, VStream(sync_complete_ack));
     testPeer->ProcessMessage(message_sync_complete_ack);
 
-    CAT->Wait();
+    usleep(50000);
     DAG->Wait();
 
     ASSERT_EQ(testPeer->GetInvTaskSize(), 0);
@@ -181,7 +182,7 @@ TEST_F(TestSync, test_version_ack) {
     NetMessage message_pendingSet_bundle(peer_handle, BUNDLE, VStream(pending_set));
     testPeer->ProcessMessage(message_pendingSet_bundle);
 
-    CAT->Wait();
+    usleep(50000);
     DAG->Wait();
 
     ASSERT_EQ(testPeer->GetInvTaskSize(), 0);
@@ -206,6 +207,8 @@ TEST_F(TestSync, test_version_ack) {
 
     // receive GetData
     testPeer->ProcessMessage(message_getData_Cmp);
+
+    usleep(50000);
     DAG->Wait();
 
     // send Bundle


### PR DESCRIPTION
In TestSync, we block the main thread by DAG::Wait where the main thread yields whenever the threadpool is not idle. However, there are two potential issues with this solution:

1. the method ThreadPool::IsIdle is not lock protected, and thus checking working state and checking task size together is not atomic;

2. when a threadpool is idle, it doesn't mean there won't be more tasks to be added.

Since adding the lock to the threadpool for checking working state will also affect the efficiency of adding tasks, and solving the second issue is more complicated, and thus we may not want to refactor the code only for testing purpose, we decide to keep things simple and simply make the main thread sleep before DAG::Wait to ensure that all tasks are already added to the threadpool before the main thread starts to check the threadpool working state.