### PR TITLE
Send bundles in a random order

### DIFF
--- a/src/net/peer.cpp
+++ b/src/net/peer.cpp
@@ -366,6 +366,7 @@ void Peer::ProcessBundle(const std::shared_ptr<Bundle>& bundle) {
                 }
             } else {
                 orphanLvsPool[bundle->nonce] = bundle;
+                AddPendingGetDataTask(*task);
                 spdlog::info("The Bundle answers a GetDataTask of type {}, wait for prev level set to be solidified, "
                              "lvsPool size = {}",
                              task->type, orphanLvsPool.size());


### PR DESCRIPTION
1. randomly shuffle the order of bundles in the synchronization test
2. fix a bug in processing bundles