### PR TITLE
Add lock to Chains and fix Miner

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -123,9 +123,11 @@ int Init(int argc, char* argv[]) {
 
     CAT = std::make_unique<Caterpillar>(config->GetDBPath());
 
-    // put genesis block into cat
-    std::vector<RecordPtr> genesisLvs = {std::make_shared<NodeRecord>(GENESIS_RECORD)};
-    CAT->StoreRecords(genesisLvs);
+    if (config->IsStartWithNewDB()) {
+        // put genesis block into cat
+        std::vector<RecordPtr> genesisLvs = {std::make_shared<NodeRecord>(GENESIS_RECORD)};
+        CAT->StoreRecords(genesisLvs);
+    }
 
     DAG = std::make_unique<DAGManager>();
     if (!DAG->Init()) {

--- a/test/core/test_synchronization.cpp
+++ b/test/core/test_synchronization.cpp
@@ -16,26 +16,13 @@ public:
         config->SetDBPath("testSync/");
         spdlog::set_level(spdlog::level::debug);
 
-
-        file::SetDataDirPrefix(config->GetDBPath());
-        CAT = std::make_unique<Caterpillar>(config->GetDBPath());
-
-        // Initialize CAT with genesis block
-        std::vector<RecordPtr> genesisLvs = {std::make_shared<NodeRecord>(GENESIS_RECORD)};
-        CAT->StoreRecords(genesisLvs);
-        CAT->EnableOBC();
-
-        DAG         = std::make_unique<DAGManager>();
+        EpicTestEnvironment::SetUpDAG(config->GetDBPath());
         peerManager = std::make_unique<TestPM>();
     }
 
     static void TearDownTestCase() {
-        std::string cmd = "rm -r " + config->GetDBPath();
-        system(cmd.c_str());
-
+        EpicTestEnvironment::TearDownDAG(config->GetDBPath());
         config.reset();
-        DAG.reset();
-        CAT.reset();
     }
 
     TestFactory fac;

--- a/test/test-methods/test_env.h
+++ b/test/test-methods/test_env.h
@@ -31,6 +31,10 @@ public:
         file::SetDataDirPrefix(dirPath + os.str());
         CAT = std::make_unique<Caterpillar>(dirPath + os.str());
         DAG = std::make_unique<DAGManager>();
+
+        // Initialize DB with genesis
+        std::vector<RecordPtr> genesisLvs = {std::make_shared<NodeRecord>(GENESIS_RECORD)};
+        CAT->StoreRecords(genesisLvs);
     }
 
     static void TearDownDAG(std::string dirPath) {

--- a/test/utils/test_miner.cpp
+++ b/test/utils/test_miner.cpp
@@ -36,15 +36,13 @@ TEST_F(TestMiner, Solve) {
 
 TEST_F(TestMiner, Run) {
     EpicTestEnvironment::SetUpDAG("test_miner/");
-    std::vector<RecordPtr> genesisLvs = {std::make_shared<NodeRecord>(GENESIS_RECORD)};
-    CAT->StoreRecords(genesisLvs);
 
     peerManager = std::make_unique<PeerManager>();
     MEMPOOL     = std::make_unique<MemPool>();
 
     Miner m(2);
     m.Run();
-    sleep(1);
+    usleep(500000);
     m.Stop();
 
     usleep(50000);
@@ -58,6 +56,8 @@ TEST_F(TestMiner, Run) {
     }
 
     EpicTestEnvironment::TearDownDAG("test_miner/");
+    peerManager.reset();
+    MEMPOOL.reset();
 }
 
 TEST_F(TestMiner, MineGenesis) {


### PR DESCRIPTION
Issues found with Miner:

1. `DAG::milestoneChains_` is not lock-protected but is accessed by multiple threads in DAG and Miner, causing memory error;

2. the `runner_` thread stuck at the while loop in `Miner::Solve`, before aborting the `solverPool_`:

``` 
while (final_nonce.load() == 0) {
    std::this_thread::yield();
}
```

This happens after calling `Miner::Stop`, since the `final_nonce` will stay at 0 after the `solverPool_` stops. This causes the `runner_` thread never able to join;

3. When calling `ThreadPool::Abort`, there is still chance that tasks are added to the task queue after clearing it;

4. There is still a small chance that `final_nonce` goes out of scope since tasks may be added after calling `Abort`. Haven't found why `Abort` does not do the job well. Making the `final_nonce` a class member of `Miner` temporarily solves this issue.

Ran `TestMiner::Run` repeatedly for 1000 times with these fixed and haven't found more error yet. 