### PR TITLE
173: Epic Client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(SRC_CODE
         )
 
 set(SRC_MAIN src/main.cpp)
+set(SRC_CLIENT_MAIN src/epicc/main.cpp)
 
 # test codes
 set(TEST_METHODS_SRCS test/test-methods)
@@ -141,6 +142,15 @@ add_library(epiccore STATIC ${SRC_CODE})
 
 # generate executable
 add_executable(epic  ${SRC_MAIN})
+
+add_executable(epicc  ${SRC_CLIENT_MAIN}
+        ${RPC_DIR}/rpc_client.cpp
+        ${PROTO_SRCS}
+        ${GRPC_SRCS}
+        )
+target_link_libraries(epicc protobuf::libprotobuf)
+target_link_libraries(epicc gRPC::grpc++_reflection)
+
 add_executable(epictest ${TEST_MAIN}  ${TEST_CODE})
 
 target_link_libraries(epiccore ${LIBEVENT_LIBRARIES})
@@ -149,6 +159,7 @@ target_link_libraries(epiccore ${Secp256k1_LIBRARY})
 target_link_libraries(epiccore ${GMP_LIBRARY})
 target_link_libraries(epiccore protobuf::libprotobuf)
 target_link_libraries(epiccore gRPC::grpc++_reflection)
+     
 
 target_link_libraries(epic epiccore)
 add_dependencies(epic epiccore)

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -77,3 +77,33 @@ message GetLevelSetSizeRequest {
 message GetLevelSetSizeResponse {
     uint64 size = 1;    
 }
+
+service CommanderRPC {
+    rpc Status (StatusRequest) returns (StatusResponse);
+    rpc Stop (StopRequest) returns (StopResponse);
+    rpc StartMiner (StartMinerRequest) returns (StartMinerResponse);
+    rpc StopMiner (StopMinerRequest) returns (StopMinerResponse);
+}
+
+message StopRequest {}
+
+message StopResponse {}
+
+message StartMinerRequest {}
+
+message StartMinerResponse {
+    bool success = 1;    
+}
+
+message StopMinerRequest {}
+
+message StopMinerResponse {
+    bool success = 1;    
+}
+
+message StatusRequest {}
+
+message StatusResponse {
+    bool isMinerRunning = 1;
+    Hash latestMSHash = 2;
+}

--- a/src/epicc/main.cpp
+++ b/src/epicc/main.cpp
@@ -1,0 +1,86 @@
+#include "cxxopts.hpp"
+#include "rpc_client.h"
+#include "spdlog/sinks/basic_file_sink.h"
+
+enum : uint8_t {
+    NORMAL_EXIT = 0,
+    COMMANDLINE_INIT_FAILURE,
+    LOG_INIT_FAILURE,
+    PARAMS_INIT_FAILURE,
+};
+
+int main(int argc, char** argv) {
+    std::string command;
+    uint16_t rpc_port;
+    // clang-format off
+    cxxopts::Options options("epicc", "epic client");
+    options.positional_help("COMMAND. available commands: status, start-miner, stop-miner, stop").show_positional_help();
+
+    options
+    .add_options("command")
+    ("command", "Command", cxxopts::value<std::string>(command)->default_value(""))
+    ;
+
+    options.add_options()
+    ("h,help", "print this message", cxxopts::value<bool>())
+
+    ("rpc-port", "client rpc port which is used to connect to the server", cxxopts::value<uint16_t>(rpc_port)->default_value("3777"))
+    ;
+
+    options.parse_positional({"command"});
+    // clang-format on
+    try {
+        auto parsed_options = options.parse(argc, argv);
+        if (parsed_options["help"].as<bool>()) {
+            std::cout << options.help() << std::endl;
+            return NORMAL_EXIT;
+        }
+
+        if (command == "status") {
+            RPCClient client(
+                grpc::CreateChannel("0.0.0.0:" + std::to_string(rpc_port), grpc::InsecureChannelCredentials()));
+            auto r = client.Status();
+            if (r.has_value()) {
+                std::cout << "Miner status: " << (r.value().isminerrunning() ? "RUNNING" : "NOT RUNNING") << std::endl;
+                std::cout << "Latest milestone hash: " << r.value().latestmshash().hash() << std::endl;
+            } else {
+                std::cout << "No epic is running on " << std::to_string(rpc_port) << " port" << std::endl;
+            }
+        } else if (command == "stop") {
+            RPCClient client(
+                grpc::CreateChannel("0.0.0.0:" + std::to_string(rpc_port), grpc::InsecureChannelCredentials()));
+            if (client.Stop()) {
+                std::cout << "OK";
+            } else {
+                std::cout << "No epic is running on " << std::to_string(rpc_port) << " port" << std::endl;
+            }
+        } else if (command == "start-miner") {
+            RPCClient client(
+                grpc::CreateChannel("0.0.0.0:" + std::to_string(rpc_port), grpc::InsecureChannelCredentials()));
+            auto r = client.StartMiner();
+            if (r.has_value()) {
+                std::cout << ((*r) ? "OK" : "FAIL: Miner is already running") << std::endl;
+            } else {
+                std::cout << "No epic is running on " << std::to_string(rpc_port) << " port" << std::endl;
+            }
+        } else if (command == "stop-miner") {
+            RPCClient client(
+                grpc::CreateChannel("0.0.0.0:" + std::to_string(rpc_port), grpc::InsecureChannelCredentials()));
+            auto r = client.StopMiner();
+            if (r.has_value()) {
+                std::cout << ((*r) ? "OK" : "FAIL: Miner is already stopped") << std::endl;
+            } else {
+                std::cout << "No epic is running on " << std::to_string(rpc_port) << " port" << std::endl;
+            }
+        } else {
+            std::cout << options.help() << std::endl;
+            std::cerr << "please specify one of the commands" << std::endl;
+            exit(COMMANDLINE_INIT_FAILURE);
+        }
+    } catch (const cxxopts::OptionException& e) {
+        std::cout << options.help() << std::endl;
+        std::cerr << "error parsing options: " << e.what() << std::endl;
+        exit(COMMANDLINE_INIT_FAILURE);
+    }
+    return NORMAL_EXIT;
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,11 +19,15 @@ std::unique_ptr<MemPool> memPool;
 std::unique_ptr<Caterpillar> CAT;
 std::unique_ptr<DAGManager> DAG;
 std::unique_ptr<RPCServer> rpc_server;
+std::unique_ptr<Miner> MINER;
 
 // TODO: init mempool
 std::unique_ptr<MemPool> MEMPOOL;
 
-static std::atomic_bool b_shutdown = false;
+ECCVerifyHandle handle;
+
+std::atomic_bool b_shutdown = false;
+
 typedef void (*signal_handler_t)(int);
 
 static void KickShutdown(int) {
@@ -142,8 +146,19 @@ int Init(int argc, char* argv[]) {
     peerManager = std::make_unique<PeerManager>();
 
     /*
+     * Initialize ECC
+     */
+    ECC_Start();
+    handle = ECCVerifyHandle();
+
+    /*
      * Load wallet TODO
      */
+
+    /*
+     * Initialize miner
+     */
+    MINER = std::make_unique<Miner>();
 
     /*
      * Create rpc instance
@@ -370,6 +385,10 @@ void ShutDown() {
     DAG.reset();
     memPool.reset();
     peerManager.reset();
+    MINER.reset();
+
+    ECC_Stop();
+    handle.~ECCVerifyHandle();
 
     spdlog::info("shutdown finish");
     spdlog::shutdown();

--- a/src/init.h
+++ b/src/init.h
@@ -8,6 +8,9 @@
 #include "file_utils.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
+extern std::atomic_bool b_shutdown;
+extern ECCVerifyHandle handle;
+
 enum : uint8_t {
     NORMAL_EXIT = 0,
     COMMANDLINE_INIT_FAILURE,

--- a/src/miner.h
+++ b/src/miner.h
@@ -33,6 +33,10 @@ public:
         }
     }
 
+    bool IsRunning() {
+        return enabled_.load();
+    }
+
     void Solve(Block& b) {
         arith_uint256 target = b.GetTargetAsInteger();
         size_t nthreads      = solverPool_.GetThreadSize();
@@ -183,4 +187,5 @@ private:
     }
 };
 
+extern std::unique_ptr<Miner> MINER;
 #endif /* ifndef __SRC_POW_H__ */

--- a/src/rpc/rpc_client.h
+++ b/src/rpc/rpc_client.h
@@ -1,13 +1,10 @@
 #ifndef __SRC_RPCCLIENT_H__
 #define __SRC_RPCCLIENT_H__
 
+#include "spdlog/sinks/basic_file_sink.h"
 #include <grpc++/grpc++.h>
 #include <rpc.grpc.pb.h>
 #include <rpc.pb.h>
-#include <rpc_tools.h>
-
-#include "block.h"
-#include "net_address.h"
 
 using rpc::BasicBlockExplorerRPC;
 using rpc::GetBlockRequest;
@@ -21,23 +18,40 @@ using rpc::GetLevelSetSizeResponse;
 using rpc::GetNewMilestoneSinceRequest;
 using rpc::GetNewMilestoneSinceResponse;
 
+using rpc::CommanderRPC;
+using rpc::StartMinerRequest;
+using rpc::StartMinerResponse;
+using rpc::StatusRequest;
+using rpc::StatusResponse;
+using rpc::StopMinerRequest;
+using rpc::StopMinerResponse;
+using rpc::StopRequest;
+using rpc::StopResponse;
+
 class RPCClient {
 public:
     RPCClient(std::shared_ptr<grpc::Channel> channel);
 
-    std::optional<rpc::Block> GetBlock(const uint256&);
+    std::optional<rpc::Block> GetBlock(std::string&);
 
-    std::optional<std::vector<rpc::Block>> GetLevelSet(const uint256&);
+    std::optional<std::vector<rpc::Block>> GetLevelSet(std::string&);
 
-    std::optional<size_t> GetLevelSetSize(const uint256&);
+    std::optional<size_t> GetLevelSetSize(std::string&);
 
     std::optional<rpc::Block> GetLatestMilestone();
 
-    std::optional<std::vector<rpc::Block>> GetNewMilestoneSince(const uint256&, size_t);
+    std::optional<std::vector<rpc::Block>> GetNewMilestoneSince(std::string&, size_t);
+    std::optional<StatusResponse> Status();
 
+    bool Stop();
+
+    std::optional<bool> StartMiner();
+
+    std::optional<bool> StopMiner();
 
 private:
-    std::unique_ptr<BasicBlockExplorerRPC::Stub> stub_;
+    std::unique_ptr<BasicBlockExplorerRPC::Stub> be_stub_;
+    std::unique_ptr<CommanderRPC::Stub> commander_stub_;
 };
 
 #endif //__SRC_RPCCLIENT_H__

--- a/src/rpc/rpc_server.h
+++ b/src/rpc/rpc_server.h
@@ -8,7 +8,8 @@
 #include <thread>
 
 #include "block.h"
-#include "caterpillar.h"
+#include "init.h"
+#include "miner.h"
 #include "net_address.h"
 #include "spdlog.h"
 
@@ -23,6 +24,16 @@ using rpc::GetLevelSetSizeRequest;
 using rpc::GetLevelSetSizeResponse;
 using rpc::GetNewMilestoneSinceRequest;
 using rpc::GetNewMilestoneSinceResponse;
+
+using rpc::CommanderRPC;
+using rpc::StartMinerRequest;
+using rpc::StartMinerResponse;
+using rpc::StatusRequest;
+using rpc::StatusResponse;
+using rpc::StopMinerRequest;
+using rpc::StopMinerResponse;
+using rpc::StopRequest;
+using rpc::StopResponse;
 
 class BasicBlockExplorerRPCServiceImpl final : public BasicBlockExplorerRPC::Service {
     grpc::Status GetBlock(grpc::ServerContext* context,
@@ -44,6 +55,20 @@ class BasicBlockExplorerRPCServiceImpl final : public BasicBlockExplorerRPC::Ser
     grpc::Status GetLatestMilestone(grpc::ServerContext* context,
                                     const GetLatestMilestoneRequest* request,
                                     GetLatestMilestoneResponse* reply) override;
+};
+
+class CommanderRPCServiceImpl final : public CommanderRPC::Service {
+    grpc::Status Status(grpc::ServerContext* context, const StatusRequest* request, StatusResponse* reply) override;
+
+    grpc::Status Stop(grpc::ServerContext* context, const StopRequest* request, StopResponse* reply) override;
+
+    grpc::Status StartMiner(grpc::ServerContext* context,
+                            const StartMinerRequest* request,
+                            StartMinerResponse* reply) override;
+
+    grpc::Status StopMiner(grpc::ServerContext* context,
+                           const StopMinerRequest* request,
+                           StopMinerResponse* reply) override;
 };
 
 class RPCServer {

--- a/src/rpc/rpc_tools.h
+++ b/src/rpc/rpc_tools.h
@@ -6,7 +6,6 @@
 #include <rpc.pb.h>
 
 #include "block.h"
-#include "net_address.h"
 
 uint256 RPCHashToHash(const rpc::Hash&);
 

--- a/test/rpc/rpc_test.cpp
+++ b/test/rpc/rpc_test.cpp
@@ -40,8 +40,9 @@ std::string TestRPCServer::adr = "";
 TEST_F(TestRPCServer, GetBlock) {
     RPCClient client(grpc::CreateChannel(adr, grpc::InsecureChannelCredentials()));
 
-    auto g   = std::make_shared<NodeRecord>(GENESIS_RECORD);
-    auto res = client.GetBlock(g->cblock->GetHash());
+    auto g        = std::make_shared<NodeRecord>(GENESIS_RECORD);
+    auto req_hash = std::to_string(g->cblock->GetHash());
+    auto res      = client.GetBlock(req_hash);
     ASSERT_TRUE(res.has_value());
     auto expected = HashToRPCHash(g->cblock->GetHash());
     EXPECT_EQ(res.value().block_hash().hash(), expected->hash());
@@ -69,11 +70,13 @@ TEST_F(TestRPCServer, GetLevelSetAndItsSize) {
     RPCClient client(grpc::CreateChannel(adr, grpc::InsecureChannelCredentials()));
 
     for (int i = 0; i < size; ++i) {
-        auto res_size = client.GetLevelSetSize(lvs[i]->cblock->GetHash());
+        auto req_hash = std::to_string(lvs[i]->cblock->GetHash());
+        auto res_size = client.GetLevelSetSize(req_hash);
         ASSERT_TRUE(res_size.has_value());
         EXPECT_EQ(res_size.value(), size);
     }
-    auto res_set = client.GetLevelSet(lvs[0]->cblock->GetHash());
+    auto req_hash = std::to_string(lvs[0]->cblock->GetHash());
+    auto res_set  = client.GetLevelSet(req_hash);
     ASSERT_TRUE(res_set.has_value());
     auto expected = HashToRPCHash(lvs[0]->cblock->GetHash());
     EXPECT_EQ(res_set.value()[0].block_hash().hash(), expected->hash());
@@ -134,7 +137,8 @@ TEST_F(TestRPCServer, GetNewMilestoneSince) {
     RPCClient client(grpc::CreateChannel(adr, grpc::InsecureChannelCredentials()));
 
     size_t request_milestone_number = 3;
-    auto res = client.GetNewMilestoneSince(mss_to_check[0]->cblock->GetHash(), request_milestone_number);
+    auto req_hash                   = std::to_string(mss_to_check[0]->cblock->GetHash());
+    auto res                        = client.GetNewMilestoneSince(req_hash, request_milestone_number);
     ASSERT_TRUE(res.has_value());
     ASSERT_EQ(res.value().size(), request_milestone_number);
     for (int i = 0; i < request_milestone_number; ++i) {


### PR DESCRIPTION
Modify the way epic starts up.
Introduce Commander RPC
Add commands start, stop, start-miner, stop-miner and status.
Make start command default.
Run server as a daemon by default and add --fg option to
run it in the foreground.
Add rpc_port option for the client.
Add keys and miner to the init process