### PR TITLE
Modify target, set data[0,224] to be 0

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -168,7 +168,7 @@ private:
     std::optional<TXOC> ValidateTx(NodeRecord& record);
     bool IsValidDistance(const NodeRecord&, const arith_uint256&);
 
-    const Coin& GetPrevReward(const NodeRecord& rec) {
+    Coin GetPrevReward(const NodeRecord& rec) {
         return GetRecord(rec.cblock->GetPrevHash())->cumulativeReward;
     }
 

--- a/src/consensus.cpp
+++ b/src/consensus.cpp
@@ -35,10 +35,14 @@ void ChainState::UpdateDifficulty(uint32_t blockUpdateTime) {
         return;
     }
 
-    hashRate        = GetParams().interval * GetMsDifficulty() / timespan;
+    hashRate = GetParams().interval * GetMsDifficulty() / timespan;
+
     milestoneTarget = milestoneTarget * timespan / targetTimespan;
-    blockTarget     = milestoneTarget * arith_uint256(GetParams().targetTPS);
+    milestoneTarget.Round(sizeof(uint32_t));
+
+    blockTarget = milestoneTarget * arith_uint256(GetParams().targetTPS);
     blockTarget *= GetParams().timeInterval;
+    blockTarget.Round(sizeof(uint32_t));
 
     if (blockTarget > GetParams().maxTarget) {
         // in case that it is not difficult in this round

--- a/src/utils/arith_uint256.h
+++ b/src/utils/arith_uint256.h
@@ -294,6 +294,13 @@ public:
     arith_uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr);
     uint32_t GetCompact(bool fNegative = false) const;
 
+    void Round(size_t bytes) {
+        if (bytes > 32) {
+            return;
+        }
+        memset(pn, 0, 32 - bytes);
+    }
+
     friend uint256 ArithToUint256(const arith_uint256&);
     friend arith_uint256 UintToArith256(const uint256&);
 };


### PR DESCRIPTION
* remove reference of the return type in the function `const Coin& GetPrevReward(const NodeRecord& rec)` since the returned value is rvalue and will be destroyed soon, which makes the reference invalid
* only keeps the last 32 bits of diffTarget(256 bits) in updating difficulty to avoid rounding issue between the memory(256 bits) and the file(32 bits)