### PR TITLE
upgrade dependencies to more recent versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ script:
   - cmake --version
   - which cmake
   - if [ ${TRAVIS_OS_NAME} == 'osx' ]; then cmake -DUNITTEST_COVERAGE=ON -DADDRESS_DETECT=OFF -DCMAKE_BUILD_TYPE=Debug ..; else cmake -DUNITTEST_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..; fi
-  - make -j
+  - make -j2
   - ./../bin/epictest --gtest_filter="-TestTrimmer*:TestMiner.SolveCuckaroo*"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,6 @@ matrix:
             - automake
             - libtool
             - gmp 
-            - c-ares
-            - gflags
-            - gperftools
       cache:
         directories:
          - $BUILD_LIB_MPATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ matrix:
          - $BUILD_LIB_MPATH
       before_install:
         - export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
-        - export CXXFLAGS="-I/usr/local/opt/openssl@1.1/include $CXXFLAGS"
         - cd $BUILD_LIB_MPATH
 
 install:
@@ -101,7 +100,7 @@ script:
   - cmake --version
   - which cmake
   - if [ ${TRAVIS_OS_NAME} == 'osx' ]; then cmake -DUNITTEST_COVERAGE=ON -DADDRESS_DETECT=OFF -DCMAKE_BUILD_TYPE=Debug ..; else cmake -DUNITTEST_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ..; fi
-  - make -j2
+  - make -j
   - ./../bin/epictest --gtest_filter="-TestTrimmer*:TestMiner.SolveCuckaroo*"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,27 +54,24 @@ matrix:
         - ssh -p99 -oStrictHostKeyChecking=no ieda@IEB024.ieda.ust.hk "rm -rf epic && git clone git@github.com:EPI-ONE/epic.git && cd epic && ./ci/deploy-build.sh"
         - ssh -p99 -oStrictHostKeyChecking=no ieda@IEB028.ieda.ust.hk "rm -rf epic && git clone git@github.com:EPI-ONE/epic.git && cd epic && ./ci/deploy-build.sh"
 
-
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode11.2
       addons:
         homebrew:
           packages:
             - autoconf
             - automake
             - libtool
-            - llvm
+            - gmp 
+            - c-ares
+            - gflags
+            - gperftools
       cache:
         directories:
          - $BUILD_LIB_MPATH
       before_install:
-        - export PATH="/usr/local/opt/llvm/bin:$PATH"
-        - export LDFLAGS="-L/usr/local/opt/llvm/lib"
-        - export CXXFLAGS="-I/usr/local/opt/llvm/include"
-        - export CC=clang && export CXX=clang++ &&  CXX_FOR_BUILD=clang++ && CC_FOR_BUILD=clang
         - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
         - export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
-        - sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
         - cd $BUILD_LIB_MPATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ matrix:
         directories:
          - $BUILD_LIB_MPATH
       before_install:
+        - export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
         - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
         - export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
         - cd $BUILD_LIB_MPATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,7 @@ matrix:
          - $BUILD_LIB_MPATH
       before_install:
         - export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
-        - export OPENSSL_INCLUDE_DIR="/usr/local/opt/openssl@1.1/include"
-        - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-        - export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+        - export CXXFLAGS="-I/usr/local/opt/openssl@1.1/include $CXXFLAGS"
         - cd $BUILD_LIB_MPATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
          - $BUILD_LIB_MPATH
       before_install:
         - export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
+        - export OPENSSL_INCLUDE_DIR="/usr/local/opt/openssl@1.1/include"
         - export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
         - export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
         - cd $BUILD_LIB_MPATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ find_package(OpenSSL REQUIRED)
 target_link_libraries(OpenSSL::Crypto)
 
 # gtest
-find_package(GTest 1.8.1 EXACT REQUIRED)
+find_package(GTest 1.10.0 REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
 #libevent
@@ -50,7 +50,7 @@ find_package(Libevent 2.1.11 EXACT REQUIRED)
 include_directories(${LIBEVENT_INCLUDE_DIRS})
 
 # rocksdb
-find_package(rocksdb REQUIRED)
+find_package(rocksdb 6.1.2 REQUIRED)
 include_directories(${ROCKSDB_INCLUDE_DIRS})
 
 # secp256k1
@@ -66,7 +66,7 @@ endif()
 include_directories(${Secp256k1_INCLUDE_DIR})
 
 # Protobuf and gRPC
-find_package(Protobuf REQUIRED)
+find_package(Protobuf 3.10.0 REQUIRED)
 find_package(GRPC REQUIRED)
 set(RPC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/rpc)
 set(PROTOS proto/rpc.proto)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 # openssl
 find_package(OpenSSL REQUIRED)
 target_link_libraries(OpenSSL::Crypto)
+include_directories(OPENSSL_INCLUDE_DIR)
 
 # gtest
 find_package(GTest 1.10.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 # openssl
 find_package(OpenSSL REQUIRED)
 target_link_libraries(OpenSSL::Crypto)
-include_directories(OPENSSL_INCLUDE_DIR)
+include_directories(${OPENSSL_INCLUDE_DIR})
 
 # gtest
 find_package(GTest 1.10.0 REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
      >   Note: if you are using MacOS 10.14 Mojave, you need to install llvm by using `brew install llvm` and manually add some required C header files. This step is complicated since MacOS Mojave removed some system headers. You may check whether you already have the required C headers by
      >
      >   `ls /Library/Developer/CommandLineTools/Packages`
->
+     >
      >   If you have something like `macOS_SDK_headers_for_macOS_10.14.pkg` in this folder, then you can skip the next step. Otherwise, please go to [Apple Developer](https://developer.apple.com/download/more/) and download `Command Line Tools (macOS 10.14) for Xcode 10.2.1.dmg` and install. After this, you will find `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`. After install this package, you will have the required system header files. Now, you can build from source.
      
 1. [Brew](https://brew.sh)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,15 +104,6 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
     brew install gmp
     ```
 
-4. `gRPC` requires `c-ares` `grpc` and `perftools`
-
-    ```bash
-    brew install c-ares
-    brew install gflags
-    brew install gperftools
-    brew link gperftools
-    ```
-    It is important that the above link is successful. In fact, it is import for all `brew link` to be successful. 
 
 
 ## Dependencies installation from source
@@ -154,36 +145,6 @@ Linux:
 git clone -b OpenSSL_1_1_1d https://github.com/openssl/openssl.git
 cd openssl
 ./config && make -j && sudo make install
-```
-
-#### Secp256k1
-
-```bash
-git clone https://github.com/bitcoin-core/secp256k1.git
-cd secp256k1
-./autogen.sh && ./configure --enable-module-recovery=yes
-make -j && sudo make install
-```
-
-#### libevent
-
-```bash
-git clone -b release-2.1.11-stable --single-branch https://github.com/libevent/libevent.git
-cd libevent
-mkdir build && cd build
-cmake ..
-make -j && sudo make install
-```
-
->   The brew-installed `libevent` on Mac does not work for now. So please compile as instructed in the above.
-
-#### Google Test
-
-```bash
-git clone -b release-1.10.0 --single-branch https://github.com/google/googletest.git
-cd googletest && mkdir build && cd build
-cmake ..
-make -j && sudo make install
 ```
 
 #### Protocol Buffers
@@ -246,4 +207,34 @@ git clone -b v6.3.6 --single-branch https://github.com/facebook/rocksdb.git
 cd rocksdb
 make shared_lib -j
 sudo make install
+```
+
+#### libevent
+
+```bash
+git clone -b release-2.1.11-stable --single-branch https://github.com/libevent/libevent.git
+cd libevent
+mkdir build && cd build
+cmake ..
+make -j && sudo make install
+```
+
+>   The brew-installed `libevent` (version 2.1.11_1) on Mac does not work smoothly for now. So please compile as instructed in the above.
+
+#### Google Test
+
+```bash
+git clone -b release-1.10.0 --single-branch https://github.com/google/googletest.git
+cd googletest && mkdir build && cd build
+cmake ..
+make -j && sudo make install
+```
+
+#### Secp256k1
+
+```bash
+git clone https://github.com/bitcoin-core/secp256k1.git
+cd secp256k1
+./autogen.sh && ./configure --enable-module-recovery=yes
+make -j && sudo make install
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,19 +74,19 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
 
 ### Mac OS X 10.15
 
-0. XCode
+0. XCode11
 
      ```bash
      xcode-select --install
      ```
      Mac provides its own C/C++ compiler and lib via XCode, `Apple clang version 11.0.0 (clang-1100.0.33.8)`
-     >   Note: if you are using MacOS 10.14 Mojave, you need to install llvm by using `brew install llvm` and manually add some required C header files. This step is complicated since MacOS Mojave removed some system headers. You may check whether you already have the required C headers by
+     >   Note: if you use XCode10 (or lower) and on OS X 10.14, you need to install llvm by using `brew install llvm` and manually add some required C header files. This step is complicated since MacOS Mojave removed some system headers. You may check whether you already have the required C headers by
      >
      >   `ls /Library/Developer/CommandLineTools/Packages`
      >
      >   If you have something like `macOS_SDK_headers_for_macOS_10.14.pkg` in this folder, then you can skip the next step. Otherwise, please go to [Apple Developer](https://developer.apple.com/download/more/) and download `Command Line Tools (macOS 10.14) for Xcode 10.2.1.dmg` and install. After this, you will find `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`. After install this package, you will have the required system header files. Now, you can build from source.
      
-1. [Brew](https://brew.sh)
+1. Brew
 
     ```bash
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,13 +125,13 @@ Mac:
 
 ```bash
 brew install cmake
-# version 3.15.2 will be installed
+# version 3.15.4 will be installed
 ```
 
 Linux:
 
 ```bash
-git clone -b v3.15.2 --single-branch https://github.com/Kitware/CMake.git
+git clone -b v3.15.4 --single-branch https://github.com/Kitware/CMake.git
 cd CMake
 ./bootstrap && make -j && sudo make install
 ```
@@ -198,7 +198,7 @@ brew install protobuf
 Linux:
 
 ```bash
-git clone -b v3.7.0 --single-branch https://github.com/protocolbuffers/protobuf.git
+git clone -b v3.10.0 --single-branch https://github.com/protocolbuffers/protobuf.git
 cd protobuf
 git submodule update --init --recursive
 ./autogen.sh && ./configure && make -j
@@ -221,7 +221,7 @@ brew install grpc
 Linux:
 
 ```bash
-git clone -b v1.24.2 --single-branch https://github.com/grpc/grpc.git
+git clone -b v1.24.0 --single-branch https://github.com/grpc/grpc.git
 cd grpc
 git submodule update --init
 make -j
@@ -242,7 +242,7 @@ brew install rocksdb
 Linux:
 
 ```bash
-git clone -b v6.2.2 --single-branch https://github.com/facebook/rocksdb.git
+git clone -b v6.3.6 --single-branch https://github.com/facebook/rocksdb.git
 cd rocksdb
 make shared_lib -j
 sudo make install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
 
 ## Dependencies installation from source
 
-Some depencencies needs to be installed from the source. The following is the detailed instruction, with slight variation depending on Linux (Ubuntu/CentOS) or Mac.
+Some depencencies need to be installed from the source. The following is the detailed instruction, with slight variation depending on Linux (Ubuntu/CentOS) or Mac.
 
 #### CMake
 
@@ -129,8 +129,6 @@ cd CMake
 
 #### OpenSSL
 
-This is required by `libevent` and `secp256k1`. 
-
 Mac:
 
 ```bash
@@ -146,6 +144,8 @@ git clone -b OpenSSL_1_1_1d https://github.com/openssl/openssl.git
 cd openssl
 ./config && make -j && sudo make install
 ```
+
+This is required by `libevent` and `secp256k1`. 
 
 #### Protocol Buffers
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,29 +72,30 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
     sudo yum install gmp-devel
     ```
 
-### Mac OS X 10.14
+### Mac OS X 10.15
 
-0. Xcode and [Brew](https://brew.sh)
+0. XCode
 
-    ```bash
-    xcode-select --install
-    ```
-    Mac provides its own C/C++ compiler and lib, `Apple LLVM version 10.0.1 (clang-1001.0.46.4)`
+     ```bash
+     xcode-select --install
+     ```
+     Mac provides its own C/C++ compiler and lib via XCode, `Apple clang version 11.0.0 (clang-1100.0.33.8)`
+     >   Note: if you are using MacOS 10.14 Mojave, you need to install llvm by using `brew install llvm` and manually add some required C header files. This step is complicated since MacOS Mojave removed some system headers. You may check whether you already have the required C headers by
+     >
+     >   `ls /Library/Developer/CommandLineTools/Packages`
+>
+     >   If you have something like `macOS_SDK_headers_for_macOS_10.14.pkg` in this folder, then you can skip the next step. Otherwise, please go to [Apple Developer](https://developer.apple.com/download/more/) and download `Command Line Tools (macOS 10.14) for Xcode 10.2.1.dmg` and install. After this, you will find `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`. After install this package, you will have the required system header files. Now, you can build from source.
+     
+1. [Brew](https://brew.sh)
+
     ```bash
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     ```
 
-1. Some configure/make tools
+2. Some configure/make tools
 
     ```bash
     brew install automake autoconf libtool
-    ```
-
-2. llvm
-    ```bash
-    brew install llvm
-    # You may choose to put the following in your .zshrc or .bashrc
-    export PATH="/usr/local/opt/llvm/bin:$PATH"
     ```
 
 3. (Optional) for `libsecp256k1`
@@ -111,36 +112,23 @@ We provide instructions for three operating systems: Ubuntu, CentOS and MacOS.
     brew install gperftools
     brew link gperftools
     ```
-    It is important that the above link is successful.
+    It is important that the above link is successful. In fact, it is import for all `brew link` to be successful. 
 
-    Need to export the following `PATH` for installing `gRPC` from source.
-
-    ```bash
-    export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-    export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
-    ```
-
-5. Then some C header files are required. This step is complicated since MacOS Mojave removed some system headers. First, you may check whether you already have the required C headers by
-
-    ```bash
-    ls /Library/Developer/CommandLineTools/Packages
-    ```
-
-    If you have something like `macOS_SDK_headers_for_macOS_10.14.pkg` in this folder, then you can skip the next step. Otherwise, please go to [Apple Developer](https://developer.apple.com/download/more/) and download `Command Line Tools (macOS 10.14) for Xcode 10.2.1.dmg` and install. After this, you will find `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`. After install this package, you will have the required system header files. Now, you can build from source.
 
 ## Dependencies installation from source
 
-Some depencencies needs to be installed from the source. The following are detailed instructions, with slight variation depending on Linux (Ubuntu/CentOS) or Mac.
+Some depencencies needs to be installed from the source. The following is the detailed instruction, with slight variation depending on Linux (Ubuntu/CentOS) or Mac.
 
 #### CMake
 
-You can easily install `cmake` version 3.15.2 on Mac by
+Mac:
 
 ```bash
 brew install cmake
+# version 3.15.2 will be installed
 ```
 
-You have to `cmake` from source on Linux.
+Linux:
 
 ```bash
 git clone -b v3.15.2 --single-branch https://github.com/Kitware/CMake.git
@@ -148,25 +136,27 @@ cd CMake
 ./bootstrap && make -j && sudo make install
 ```
 
-#### openssl
+#### OpenSSL
 
-This is required by `libevent` and `secp256k1`. Version 1.1.1c can be installed on Mac by
+This is required by `libevent` and `secp256k1`. 
+
+Mac:
 
 ```bash
 brew install openssl@1.1
 # The following is needed for libevent install
-export OPENSSL_ROOT_DIR="/usr/local/Cellar/openssl@1.1/1.1.1c"
+export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
 ```
 
-For recent version, you need to install it from source on linux.
+Linux:
 
 ```bash
-git clone -b OpenSSL_1_1_1c https://github.com/openssl/openssl.git
+git clone -b OpenSSL_1_1_1d https://github.com/openssl/openssl.git
 cd openssl
 ./config && make -j && sudo make install
 ```
 
-#### secp256k1
+#### Secp256k1
 
 ```bash
 git clone https://github.com/bitcoin-core/secp256k1.git
@@ -185,28 +175,27 @@ cmake ..
 make -j && sudo make install
 ```
 
-<aside class="warning">
-The brew-installed `libevent` on Mac does not work. So please compile as instructed in the above.
-</aside>
+>   The brew-installed `libevent` on Mac does not work for now. So please compile as instructed in the above.
 
-#### GoogleTest
+#### Google Test
 
 ```bash
-git clone -b release-1.8.1 --single-branch https://github.com/google/googletest.git
+git clone -b release-1.10.0 --single-branch https://github.com/google/googletest.git
 cd googletest && mkdir build && cd build
 cmake ..
 make -j && sudo make install
 ```
 
-#### protobuf
+#### Protocol Buffers
 
-`protobuf` version 3.7.0 can be installed simply via brew on Mac
+Mac:
 
 ```bash
-brew install protobuf@3.7
+brew install protobuf
+# version 3.10.0 will be installed
 ```
 
-For recent version, you need to install it from srouce on linux.
+Linux:
 
 ```bash
 git clone -b v3.7.0 --single-branch https://github.com/protocolbuffers/protobuf.git
@@ -218,39 +207,39 @@ sudo make install
 sudo ldconfig # refresh shared library cache.
 ```
 
-If "make check" fails, you can still install, but it is likely that some features of this library will not work correctly on your system. Proceed at your own risk.[https://github.com/protocolbuffers/protobuf/blob/master/src/README.md](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)
+If "make check" fails, you can still install, but it is likely that some features of this library will not work correctly on your system. Proceed at your own risk.  [https://github.com/protocolbuffers/protobuf/blob/master/src/README.md](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md)
 
 #### gRPC
 
-The following instruction is from [https://github.com/grpc/grpc/blob/master/BUILDING.md](https://github.com/grpc/grpc/blob/master/BUILDING.md)
+Mac:
 
 ```bash
-git clone -b v1.20.0 --single-branch https://github.com/grpc/grpc.git
-cd grpc
+brew install grpc
+# version 1.23.0 will be installed
+```
 
-# please use the following for Mac
-LIBTOOL=glibtool LIBTOOLIZE=glibtoolize make -j
-# please use the following for Linux
+Linux:
+
+```bash
+git clone -b v1.24.2 --single-branch https://github.com/grpc/grpc.git
+cd grpc
 git submodule update --init
 make -j
 sudo make install
 ```
 
-<aside class="warning">
-The brew-installed `gRPC` on Mac does not work. So please compile as instructed in the above.
-Also, `gRPC` v1.22.x seems to have issues. So we still use v1.20.0 for now despite the existence of more recent releases.
-</aside>
-
+The above instruction is from [https://github.com/grpc/grpc/blob/master/BUILDING.md](https://github.com/grpc/grpc/blob/master/BUILDING.md).
 
 #### RocksDB
 
-`RocksDB` version 6.1.2 can be installed simply via brew on Mac
+Mac:
 
 ```bash
 brew install rocksdb
+# version 6.1.2 will be installed
 ```
 
-The following is for linux.
+Linux:
 
 ```bash
 git clone -b v6.2.2 --single-branch https://github.com/facebook/rocksdb.git

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Builds on several esisting projects:
     - [cxxopts v2.0.0](https://github.com/jarro2783/cxxopts)
     - [cpptoml v0.1.1](https://github.com/skystrife/cpptoml)
     - [spdlog v1.3.1](https://github.com/gabime/spdlog): header file only. You may customize how to use it by editing the default [config.toml](./config.toml) file.
-********
-- The following need to be installed on your system:
+- The following dependencies need to be installed on your system:
     - `openssl` version 1.1
     - `libsecp256k1`
     - `libevent` version 2.1.11

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The implementation of this peoject is written in C++ 17.
 
 - C/C++ compilier and library
     - `gcc` version 7 or up on Linux
-    - Apple LLVM version 10.0.1 (clang-1001.0.46.4) provided by XCode
+    - Apple LLVM version 11.0.0 (clang-1100.0.33.8) provided by XCode 11
 
 - `cmake` version 3.14 or up
 
@@ -31,13 +31,13 @@ Builds on several esisting projects:
     - [spdlog v1.3.1](https://github.com/gabime/spdlog): header file only. You may customize how to use it by editing the default [config.toml](./config.toml) file.
 ********
 - The following need to be installed on your system:
-    - `openssl` version 1.1.1c
+    - `openssl` version 1.1
     - `libsecp256k1`
     - `libevent` version 2.1.11
-    - `RocksDB` version 6.2.2
-    - `protobuf` version 3.7.1
-    - `gRPC` version 1.20.0
-    - `GoogleTest` version 1.8.1
+    - `RocksDB` version 6.1.2 or up
+    - `protobuf` version 3.10.0 
+    - `gRPC` version 1.23.0 or up
+    - `GoogleTest` version 1.10.0
 
 We test this project on Ubuntu (18.04), CentOS (7.6) and MacOS X (10.14.6). See [INSTALL.md](./INSTALL.md) for detailed installation instructions.
 

--- a/ci/install-cmake.sh
+++ b/ci/install-cmake.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_CMAKE_VERSION="3.15.2"
+EPIC_CMAKE_VERSION="3.15.4"
 EPIC_CMAKE_DIR=""cmake-"$EPIC_CMAKE_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
-    brew uninstall cmake
-    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/bb8c8bef46027924a2df271d1843b0f3cecc784a/Formula/cmake.rb
+    brew install cmake
 else
     if [[ ! -d ${EPIC_CMAKE_DIR} ]];then
         sudo rm -rf cmake*

--- a/ci/install-googletest.sh
+++ b/ci/install-googletest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_GTEST_VERSION="1.8.1"
+EPIC_GTEST_VERSION="1.10.0"
 EPIC_GTEST_DIR=""googletest-"$EPIC_GTEST_VERSION"
 
 if [[ ! -d ${EPIC_GTEST_DIR} ]];then

--- a/ci/install-grpc.sh
+++ b/ci/install-grpc.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_GRPC_VERSION="1.20.0"
+EPIC_GRPC_VERSION="1.23.0"
 EPIC_GRPC_DIR=""grpc-"$EPIC_GRPC_VERSION"
 
-if [[ ! -d ${EPIC_GRPC_DIR} ]];then
-    sudo rm -rf grpc*
-    git clone -b v${EPIC_GRPC_VERSION} --single-branch https://github.com/grpc/grpc.git ${EPIC_GRPC_DIR}
-    cd ${EPIC_GRPC_DIR}
-    git submodule update --init
-    make -j6
+if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
+    brew install grpc
 else
-    cd ${EPIC_GRPC_DIR}
-fi
+    if [[ ! -d ${epic_grpc_dir} ]];then
+        sudo rm -rf grpc*
+        git clone -b v${epic_grpc_version} --single-branch https://github.com/grpc/grpc.git ${epic_grpc_dir}
+        cd ${epic_grpc_dir}
+        git submodule update --init
+        make -j6
+    else
+        cd ${epic_grpc_dir}
+    fi
 
-sudo make install
-cd ..
+    sudo make install
+    cd ..
+fi

--- a/ci/install-grpc.sh
+++ b/ci/install-grpc.sh
@@ -6,14 +6,14 @@ EPIC_GRPC_DIR=""grpc-"$EPIC_GRPC_VERSION"
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
     brew install grpc
 else
-    if [[ ! -d ${epic_grpc_dir} ]];then
+    if [[ ! -d ${EPIC_GRPC_DIR} ]];then
         sudo rm -rf grpc*
-        git clone -b v${epic_grpc_version} --single-branch https://github.com/grpc/grpc.git ${epic_grpc_dir}
-        cd ${epic_grpc_dir}
+        git clone -b v${EPIC_GRPC_VERSION} --single-branch https://github.com/grpc/grpc.git ${EPIC_GRPC_DIR}
+        cd ${EPIC_GRPC_DIR}
         git submodule update --init
         make -j6
     else
-        cd ${epic_grpc_dir}
+        cd ${EPIC_GRPC_DIR}
     fi
 
     sudo make install

--- a/ci/install-grpc.sh
+++ b/ci/install-grpc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_GRPC_VERSION="1.23.0"
+EPIC_GRPC_VERSION="1.24.0"
 EPIC_GRPC_DIR=""grpc-"$EPIC_GRPC_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then

--- a/ci/install-libevent.sh
+++ b/ci/install-libevent.sh
@@ -3,11 +3,6 @@ set -ev
 EPIC_LIBEVENT_VERSION="2.1.11"
 EPIC_LIBEVENT_DIR=""libevent-"$EPIC_LIBEVENT_VERSION"
 
-if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
-  echo $OPENSSL_ROOT_DIR
-  export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
-fi
-
 if [[ ! -d ${EPIC_LIBEVENT_DIR} ]];then
     sudo rm -rf libevent*
     git clone -b release-${EPIC_LIBEVENT_VERSION}-stable --single-branch https://github.com/libevent/libevent.git ${EPIC_LIBEVENT_DIR}

--- a/ci/install-libevent.sh
+++ b/ci/install-libevent.sh
@@ -3,11 +3,12 @@ set -ev
 EPIC_LIBEVENT_VERSION="2.1.11"
 EPIC_LIBEVENT_DIR=""libevent-"$EPIC_LIBEVENT_VERSION"
 
+sudo rm -rf libevent*
 if [[ ! -d ${EPIC_LIBEVENT_DIR} ]];then
     sudo rm -rf libevent*
     git clone -b release-${EPIC_LIBEVENT_VERSION}-stable --single-branch https://github.com/libevent/libevent.git ${EPIC_LIBEVENT_DIR}
     cd ${EPIC_LIBEVENT_DIR} && mkdir build && cd build
-    echo $OPENSSL_ROOT_DIR $OPENSSL_INCLUDE_DIR
+    echo $OPENSSL_ROOT_DIR 
     cmake ..
     make -j6
 else

--- a/ci/install-libevent.sh
+++ b/ci/install-libevent.sh
@@ -3,12 +3,15 @@ set -ev
 EPIC_LIBEVENT_VERSION="2.1.11"
 EPIC_LIBEVENT_DIR=""libevent-"$EPIC_LIBEVENT_VERSION"
 
-sudo rm -rf libevent*
+if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
+  export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
+  echo $OPENSSL_ROOT_DIR 
+fi
+
 if [[ ! -d ${EPIC_LIBEVENT_DIR} ]];then
     sudo rm -rf libevent*
     git clone -b release-${EPIC_LIBEVENT_VERSION}-stable --single-branch https://github.com/libevent/libevent.git ${EPIC_LIBEVENT_DIR}
     cd ${EPIC_LIBEVENT_DIR} && mkdir build && cd build
-    echo $OPENSSL_ROOT_DIR 
     cmake ..
     make -j6
 else

--- a/ci/install-libevent.sh
+++ b/ci/install-libevent.sh
@@ -4,8 +4,8 @@ EPIC_LIBEVENT_VERSION="2.1.11"
 EPIC_LIBEVENT_DIR=""libevent-"$EPIC_LIBEVENT_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
+  echo $OPENSSL_ROOT_DIR
   export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
-  echo $OPENSSL_ROOT_DIR 
 fi
 
 if [[ ! -d ${EPIC_LIBEVENT_DIR} ]];then

--- a/ci/install-libevent.sh
+++ b/ci/install-libevent.sh
@@ -7,6 +7,7 @@ if [[ ! -d ${EPIC_LIBEVENT_DIR} ]];then
     sudo rm -rf libevent*
     git clone -b release-${EPIC_LIBEVENT_VERSION}-stable --single-branch https://github.com/libevent/libevent.git ${EPIC_LIBEVENT_DIR}
     cd ${EPIC_LIBEVENT_DIR} && mkdir build && cd build
+    echo $OPENSSL_ROOT_DIR $OPENSSL_INCLUDE_DIR
     cmake ..
     make -j6
 else

--- a/ci/install-openssl.sh
+++ b/ci/install-openssl.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_OPENSSL_VERSION="1_1_1c"
+EPIC_OPENSSL_VERSION="1_1_1d"
 EPIC_OPENSSL_DIR=""openssl-"$EPIC_OPENSSL_VERSION"
 
-if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then
-    sudo rm -rf openssl*
-    git clone -b OpenSSL_${EPIC_OPENSSL_VERSION} https://github.com/openssl/openssl.git ${EPIC_OPENSSL_DIR}
-    cd ${EPIC_OPENSSL_DIR}
-    ./config && make -j4
+if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
+    brew install openssl
+    export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
 else
-    cd ${EPIC_OPENSSL_DIR}
-fi
+    if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then
+        sudo rm -rf openssl*
+        git clone -b OpenSSL_${EPIC_OPENSSL_VERSION} https://github.com/openssl/openssl.git ${EPIC_OPENSSL_DIR}
+        cd ${EPIC_OPENSSL_DIR}
+        ./config && make -j4
+    else
+        cd ${EPIC_OPENSSL_DIR}
+    fi
 
-sudo make install_sw
-cd ..
+    sudo make install_sw
+    cd ..
+fi

--- a/ci/install-openssl.sh
+++ b/ci/install-openssl.sh
@@ -4,7 +4,7 @@ EPIC_OPENSSL_VERSION="1_1_1d"
 EPIC_OPENSSL_DIR=""openssl-"$EPIC_OPENSSL_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
-    brew install openssl
+    brew install openssl@1.1
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
 else
     if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then

--- a/ci/install-openssl.sh
+++ b/ci/install-openssl.sh
@@ -6,6 +6,8 @@ EPIC_OPENSSL_DIR=""openssl-"$EPIC_OPENSSL_VERSION"
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
     brew install openssl@1.1
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
+    export OPENSSL_INCLUDE_DIR="/usr/local/opt/openssl@1.1/include"
+    echo $OPENSSL_ROOT_DIR $OPENSSL_INCLUDE_DIR
 else
     if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then
         sudo rm -rf openssl*

--- a/ci/install-openssl.sh
+++ b/ci/install-openssl.sh
@@ -5,7 +5,6 @@ EPIC_OPENSSL_DIR=""openssl-"$EPIC_OPENSSL_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
     brew install openssl@1.1
-    export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
 else
     if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then
         sudo rm -rf openssl*

--- a/ci/install-openssl.sh
+++ b/ci/install-openssl.sh
@@ -6,8 +6,6 @@ EPIC_OPENSSL_DIR=""openssl-"$EPIC_OPENSSL_VERSION"
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
     brew install openssl@1.1
     export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
-    export OPENSSL_INCLUDE_DIR="/usr/local/opt/openssl@1.1/include"
-    echo $OPENSSL_ROOT_DIR $OPENSSL_INCLUDE_DIR
 else
     if [[ ! -d ${EPIC_OPENSSL_DIR} ]];then
         sudo rm -rf openssl*

--- a/ci/install-protobuf.sh
+++ b/ci/install-protobuf.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_PROTOBUF_VERSION="3.7.0"
+EPIC_PROTOBUF_VERSION="3.10.0"
 EPIC_PROTOBUF_DIR=""protobuf-"$EPIC_PROTOBUF_VERSION"
 
-if [[ ! -d ${EPIC_PROTOBUF_DIR} ]];then
-    sudo rm -rf protobuf*
-    git clone -b v${EPIC_PROTOBUF_VERSION} --single-branch https://github.com/protocolbuffers/protobuf.git ${EPIC_PROTOBUF_DIR}
-    cd ${EPIC_PROTOBUF_DIR}
-    git submodule update --init --recursive
-    ./autogen.sh && ./configure && make -j6
-    #make check
+if [ ${TRAVIS_OS_NAME} == 'osx' ]; then
+    brew install protobuf 
 else
-    cd ${EPIC_PROTOBUF_DIR}
-fi
+    if [[ ! -d ${EPIC_PROTOBUF_DIR} ]];then
+        sudo rm -rf protobuf*
+        git clone -b v${EPIC_PROTOBUF_VERSION} --single-branch https://github.com/protocolbuffers/protobuf.git ${EPIC_PROTOBUF_DIR}
+        cd ${EPIC_PROTOBUF_DIR}
+        git submodule update --init --recursive
+        ./autogen.sh && ./configure && make -j6
+        #make check
+    else
+        cd ${EPIC_PROTOBUF_DIR}
+    fi
 
-sudo make install
-if [ ${TRAVIS_OS_NAME} == 'linux' ]; then
+    sudo make install
     sudo ldconfig # refresh shared library cache.
+    cd ..
 fi
-cd ..

--- a/ci/install-rocksdb.sh
+++ b/ci/install-rocksdb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ev
-EPIC_ROCKSDB_VERSION="6.2.2"
+EPIC_ROCKSDB_VERSION="6.3.6"
 EPIC_ROCKSDB_DIR=""rocksdb-"$EPIC_ROCKSDB_VERSION"
 
 if [ ${TRAVIS_OS_NAME} == 'osx' ]; then


### PR DESCRIPTION
- update INSTALL for MacOS X 10.15 Catalina, where `llvm` is not needed
- use brew install as much as possible on MacOS X 10.15
- use same or higher versions for dependencies on Linux