### PR TITLE
Fix THE FINAL redemption bug

### DIFF
--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -170,6 +170,12 @@ private:
     std::unordered_map<uint256, uint256> prevRedempHashMap_;
 
     /**
+     * Caches all the hashes of the previous registration blocks that
+     * is going to have their redemption status changed.
+     */
+    ConcurrentHashSet<uint256> prevRegsToModify_;
+
+    /**
      * Checks whether the block contains a valide tx
      * and update its NR info
      * Returns valid TXOC and invalid TXOC of the single block

--- a/src/consensus/milestone.h
+++ b/src/consensus/milestone.h
@@ -91,7 +91,6 @@ public:
     ADD_SERIALIZE_METHODS
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(height));
         READWRITE(hashRate);
         if (ser_action.ForRead()) {
             milestoneTarget.SetCompact(ser_readdata32(s));

--- a/src/consensus/vertex.cpp
+++ b/src/consensus/vertex.cpp
@@ -70,19 +70,19 @@ size_t Vertex::GetOptimalStorageSize() {
         return optimalStorageSize_;
     }
 
-    optimalStorageSize_ += GetSizeOfVarInt(height)                                         // block height
-                           + GetSizeOfVarInt(cumulativeReward.GetValue())                  // reward
-                           + GetSizeOfVarInt(minerChainHeight)                             // miner chain height
-                           + ::GetSizeOfCompactSize(validity.size()) + validity.size() * 1 // validity
-                           + 1                                                             // RedemptionStatus
-                           + 1;                                                            // MilestoneStatus
+    optimalStorageSize_ += (1                                                               // RedemptionStatus
+                            + GetSizeOfVarInt(height)                                       // block height
+                            + GetSizeOfVarInt(cumulativeReward.GetValue())                  // reward
+                            + GetSizeOfVarInt(minerChainHeight)                             // miner chain height
+                            + ::GetSizeOfCompactSize(validity.size()) + validity.size() * 1 // validity
+                            + 1                                                             // MilestoneStatus
+    );
 
     // Milestone
     if (snapshot != nullptr) {
-        optimalStorageSize_ += (GetSizeOfVarInt(snapshot->height) // ms height
-                                + 4                               // hash rate
-                                + 4                               // ms target
-                                + 4                               // block target
+        optimalStorageSize_ += (4   // hash rate
+                                + 4 // ms target
+                                + 4 // block target
         );
     }
 

--- a/src/consensus/vertex.h
+++ b/src/consensus/vertex.h
@@ -28,9 +28,9 @@ public:
     };
 
     enum RedemptionStatus : uint8_t {
-        IS_NOT_REDEMPTION = 0, // double zero hash
-        NOT_YET_REDEEMED  = 1, // hash of previous redemption block
-        IS_REDEEMED       = 2, // null hash
+        IS_NOT_REDEMPTION = 0,
+        NOT_YET_REDEEMED  = 1,
+        IS_REDEEMED       = 2,
     };
 
     ConstBlockPtr cblock;
@@ -63,11 +63,11 @@ public:
     ADD_SERIALIZE_METHODS
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(isRedeemed);
         READWRITE(VARINT(height));
         READWRITE(cumulativeReward);
         READWRITE(VARINT(minerChainHeight));
         READWRITE(validity);
-        READWRITE(isRedeemed);
 
         if (ser_action.ForRead()) {
             auto msFlag = static_cast<MilestoneStatus>(ser_readdata8(s));
@@ -75,7 +75,8 @@ public:
             if (msFlag > 0) {
                 Milestone ms{};
                 ::Deserialize(s, ms);
-                snapshot = std::make_shared<Milestone>(std::move(ms));
+                snapshot         = std::make_shared<Milestone>(std::move(ms));
+                snapshot->height = height;
                 if (snapshot->IsDiffTransition() && cblock) {
                     snapshot->lastUpdateTime = cblock->GetTime();
                 }

--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -251,10 +251,10 @@ void Peer::ProcessBundle(const std::shared_ptr<Bundle>& bundle) {
         auto& front = getDataTasks.Front();
         if (front->type == GetDataTask::LEVEL_SET) {
             last_bundle_ms_time = front->bundle->blocks.front()->GetTime();
-            std::swap(front->bundle->blocks.front(), front->bundle->blocks.back());
-            for (auto& block : front->bundle->blocks) {
-                DAG->AddNewBlock(block, weak_peer_.lock());
+            for (size_t i = 1; i < front->bundle->blocks.size(); ++i) {
+                DAG->AddNewBlock(front->bundle->blocks[i], weak_peer_.lock());
             }
+            DAG->AddNewBlock(front->bundle->blocks[0], weak_peer_.lock());
             spdlog::info("Received levelset ms {}", front->bundle->blocks.back()->GetHash().to_substr());
         } else if (front->type == GetDataTask::PENDING_SET) {
             for (auto& block : bundle->blocks) {

--- a/src/storage/block_store.h
+++ b/src/storage/block_store.h
@@ -55,7 +55,7 @@ public:
     /**
      * Flushes a level set to db.
      * Note that this method assumes that the milestone is
-     * the first block in the lvs.
+     * the last block in the lvs.
      */
     bool StoreLevelSet(const std::vector<VertexWPtr>& lvs);
     bool StoreLevelSet(const std::vector<VertexPtr>& lvs);

--- a/src/storage/db.cpp
+++ b/src/storage/db.cpp
@@ -45,15 +45,15 @@ static const std::vector<std::string> COLUMN_NAMES = {
 DBStore::DBStore(string dbPath) : RocksDB(std::move(dbPath), COLUMN_NAMES) {}
 
 bool DBStore::Exists(const uint256& blockHash) const {
-    MAKE_KEY_SLICE((uint64_t) GetHeight(blockHash));
+    MAKE_KEY_SLICE((uint64_t) GetHeight(blockHash))
     return !RocksDB::Get("ms", keySlice).empty();
 }
 
 size_t DBStore::GetHeight(const uint256& blkHash) const {
-    MAKE_KEY_SLICE(blkHash);
+    MAKE_KEY_SLICE(blkHash)
 
     uint64_t height = UINT_FAST64_MAX;
-    GET_VALUE(db_->DefaultColumnFamily(), height);
+    GET_VALUE(db_->DefaultColumnFamily(), height)
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -77,8 +77,8 @@ bool DBStore::IsMilestone(const uint256& blkHash) const {
 }
 
 optional<pair<FilePos, FilePos>> DBStore::GetMsPos(const uint64_t& height) const {
-    MAKE_KEY_SLICE(height);
-    GET_VALUE(handleMap_.at("ms"), {});
+    MAKE_KEY_SLICE(height)
+    GET_VALUE(handleMap_.at("ms"), {})
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -168,13 +168,13 @@ bool DBStore::WriteMsPos(const uint64_t& key,
 
 
 bool DBStore::ExistsUTXO(const uint256& key) const {
-    MAKE_KEY_SLICE(key);
+    MAKE_KEY_SLICE(key)
     return !RocksDB::Get("utxo", keySlice).empty();
 }
 
 std::unique_ptr<UTXO> DBStore::GetUTXO(const uint256& key) const {
-    MAKE_KEY_SLICE(key);
-    GET_VALUE(handleMap_.at("utxo"), nullptr);
+    MAKE_KEY_SLICE(key)
+    GET_VALUE(handleMap_.at("utxo"), nullptr)
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -187,7 +187,7 @@ std::unique_ptr<UTXO> DBStore::GetUTXO(const uint256& key) const {
 }
 
 bool DBStore::WriteUTXO(const uint256& key, const UTXOPtr& utxo) const {
-    MAKE_KEY_SLICE(key);
+    MAKE_KEY_SLICE(key)
 
     VStream value(utxo);
     Slice valueSlice(value.data(), value.size());
@@ -215,8 +215,8 @@ bool DBStore::DeleteMsPos(const uint256& h) const {
 }
 
 uint256 DBStore::GetLastReg(const uint256& key) const {
-    MAKE_KEY_SLICE(key);
-    GET_VALUE(handleMap_.at("reg"), uint256{});
+    MAKE_KEY_SLICE(key)
+    GET_VALUE(handleMap_.at("reg"), uint256{})
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -260,7 +260,7 @@ template bool DBStore::WriteInfo(const std::string&, const CircularQueue<uint256
 template <typename V>
 V DBStore::GetInfo(const std::string& k) const {
     Slice keySlice(k);
-    GET_VALUE(handleMap_.at("info"), V{});
+    GET_VALUE(handleMap_.at("info"), V{})
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
         valueSlice.Reset();
@@ -278,8 +278,8 @@ template uint16_t DBStore::GetInfo(const std::string&) const;
 template CircularQueue<uint256> DBStore::GetInfo(const std::string&) const;
 
 uint256 DBStore::GetMsHashAt(const uint64_t& height) const {
-    MAKE_KEY_SLICE(height);
-    GET_VALUE(handleMap_.at("ms"), uint256());
+    MAKE_KEY_SLICE(height)
+    GET_VALUE(handleMap_.at("ms"), uint256())
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -294,8 +294,8 @@ uint256 DBStore::GetMsHashAt(const uint64_t& height) const {
 }
 
 optional<tuple<uint64_t, uint32_t, uint32_t>> DBStore::GetVertexOffsets(const uint256& blkHash) const {
-    MAKE_KEY_SLICE(blkHash);
-    GET_VALUE(db_->DefaultColumnFamily(), {});
+    MAKE_KEY_SLICE(blkHash)
+    GET_VALUE(db_->DefaultColumnFamily(), {})
 
     try {
         VStream value(valueSlice.data(), valueSlice.data() + valueSlice.size());
@@ -333,7 +333,7 @@ bool DBStore::DeleteRegSet(const std::unordered_set<std::pair<uint256, uint256>>
 
 template <typename K, typename H, typename P1, typename P2>
 bool DBStore::WritePosImpl(const string& column, const K& key, const H& h, const P1& b, const P2& r) const {
-    MAKE_KEY_SLICE(key);
+    MAKE_KEY_SLICE(key)
 
     VStream value;
     value.reserve(sizeof(H) + sizeof(P1) + sizeof(P2));

--- a/src/tools/toml_specifacation.h
+++ b/src/tools/toml_specifacation.h
@@ -118,7 +118,6 @@ auto VertexToToml(const VertexPtr& vertex) {
     if (vertex->isMilestone) {
         auto state_info = cpptoml::make_table();
 
-        state_info->insert("milestone_height", vertex->snapshot->height);
         state_info->insert("chain_work", vertex->snapshot->chainwork.GetCompact(false));
         state_info->insert("block_diff_target", vertex->snapshot->blockTarget.GetCompact(false));
         state_info->insert("ms_diff_target", vertex->snapshot->milestoneTarget.GetCompact(false));

--- a/test/rpc/test_rpc.cpp
+++ b/test/rpc/test_rpc.cpp
@@ -180,7 +180,7 @@ TEST_F(TestRPCServer, wallet_passphrase) {
         {PhraseCode::UPDATE, "Your passphrase is successfully updated!"},
     };
 
-    std::string phrase = "mypass";
+    std::string phrase         = "mypass";
     std::string phrase_phantom = "phantom";
     ASSERT_EQ(client.SetPassphrase(phrase).value(), testCode[PhraseCode::NOTSTART]);
     ASSERT_EQ(client.ChangePassphrase(phrase, phrase_phantom).value(), testCode[PhraseCode::NOTSTART]);
@@ -272,7 +272,7 @@ TEST_F(TestRPCServer, transaction_and_miner) {
         std::this_thread::yield();
     }
 
-    // malicious address 
+    // malicious address
     std::string wrong_addr = std::to_string(fac.CreateKeyPair().second.GetID()) + "deadbeef";
     ASSERT_EQ(client.CreateTx({{1, wrong_addr}}, 0).value(), testCode[AnswerCode::WRONG_ADDR] + wrong_addr);
 

--- a/test/utils/test_ser.cpp
+++ b/test/utils/test_ser.cpp
@@ -247,4 +247,5 @@ TEST_F(TestSer, SerializeEqDeserializeVertex) {
     ASSERT_EQ(soutput.size(), block1.GetOptimalStorageSize());
     ASSERT_EQ(s, soutput.str());
     ASSERT_EQ(block, block1);
+    ASSERT_EQ(block.height, block1.snapshot->height);
 }


### PR DESCRIPTION
The bug occurs when a redemption block is verified to be valid and the node goes off-line before this block is stored to file. When the node resumes, the very block is being verified for the second time (synced from peer) but will be regarded as invalid since its previous registration block's redemption status is already modified in file. The fix is simply postpone the modification of its previous reg status to the time when the block is already stored to file.

Other modifications:

* Remove height from serializer of Milestone because it is redundant information of the height stored in Vertex

* Change the order of a level set stored in file to a more comprehensible one. (For a level set [0, 1, 2, 3, 4] where 4 is the milestone, the order in storage changes from [4, 1, 2, 3, 0] to [4, 0, 1, 2, 3]).