### PR TITLE
236: Reward adjustment

### DIFF
--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -229,6 +229,7 @@ VertexPtr Chain::Verify(const ConstBlockPtr& pblock) {
 
     // validate each block in order
     for (auto& vtx : vtcs) {
+        vtx->height = height;
         if (vtx->cblock->IsFirstRegistration()) {
             const auto& blkHash = vtx->cblock->GetHash();
             prevRedempHashMap_.insert_or_assign(blkHash, const_cast<uint256&&>(blkHash));
@@ -259,7 +260,6 @@ VertexPtr Chain::Verify(const ConstBlockPtr& pblock) {
 
             vtx->UpdateReward(GetPrevReward(*vtx));
         }
-        vtx->height = height;
         verifying_.insert({vtx->cblock->GetHash(), vtx});
     }
 

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -58,7 +58,14 @@ unsigned char Params::GetKeyPrefix(KeyPrefixType type) const {
     return keyPrefixes[type];
 }
 
-Coin Params::GetReward(size_t height) const {}
+Coin Params::GetReward(size_t height) const {
+    if (height == 0) {
+        return 0;
+    }
+
+    auto epoch = (height - 1) / rewardAdjustInterval;
+    return round(baseReward / (float) (epoch + 1));
+}
 
 MainNetParams::MainNetParams() {
     version              = GENESIS_BLOCK_VERSION;
@@ -69,7 +76,8 @@ MainNetParams::MainNetParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    baseReward           = 1;
+    baseReward           = 10000;
+    rewardAdjustInterval = 3000000;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 42;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -104,7 +112,8 @@ TestNetSpadeParams::TestNetSpadeParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    baseReward           = 10;
+    baseReward           = 10000000000;
+    rewardAdjustInterval = 3000000;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 4;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -136,7 +145,8 @@ TestNetDiamondParams::TestNetDiamondParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    baseReward           = 10;
+    baseReward           = 10000000000;
+    rewardAdjustInterval = 3000000;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 0;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -167,7 +177,8 @@ UnitTestParams::UnitTestParams() {
     punctualityThred     = 20;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    baseReward           = 10;
+    baseReward           = 100;
+    rewardAdjustInterval = 5;
     msRewardCoefficient  = 1;
     cycleLen             = 0;
     sortitionCoefficient = 1;

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -58,6 +58,8 @@ unsigned char Params::GetKeyPrefix(KeyPrefixType type) const {
     return keyPrefixes[type];
 }
 
+Coin Params::GetReward(size_t height) const {}
+
 MainNetParams::MainNetParams() {
     version              = GENESIS_BLOCK_VERSION;
     targetTimespan       = TARGET_TIMESPAN;
@@ -67,7 +69,7 @@ MainNetParams::MainNetParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    reward               = 1;
+    baseReward           = 1;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 42;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -102,7 +104,7 @@ TestNetSpadeParams::TestNetSpadeParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    reward               = 10;
+    baseReward           = 10;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 4;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -134,7 +136,7 @@ TestNetDiamondParams::TestNetDiamondParams() {
     punctualityThred     = PUNTUALITY_THRESHOLD;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    reward               = 10;
+    baseReward           = 10;
     msRewardCoefficient  = REWARD_COEFFICIENT;
     cycleLen             = 0;
     sortitionCoefficient = SORTITION_COEFFICIENT;
@@ -165,7 +167,7 @@ UnitTestParams::UnitTestParams() {
     punctualityThred     = 20;
     maxTarget            = arith_uint256().SetCompact(EASIEST_COMP_DIFF_TARGET);
     maxMoney             = MAX_MONEY;
-    reward               = 10;
+    baseReward           = 10;
     msRewardCoefficient  = 1;
     cycleLen             = 0;
     sortitionCoefficient = 1;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -42,6 +42,7 @@ public:
     };
 
     // consensus parameter setting
+    uint32_t magic;
     uint16_t version;
     uint32_t targetTimespan;
     uint32_t timeInterval;
@@ -52,7 +53,7 @@ public:
     uint32_t deleteForkThreshold;
 
     Coin maxMoney;
-    Coin reward;
+    Coin baseReward;
     uint32_t msRewardCoefficient;
 
     float sortitionCoefficient;
@@ -66,7 +67,7 @@ public:
     unsigned char GetKeyPrefix(KeyPrefixType type) const;
     std::shared_ptr<Vertex> CreateGenesis() const;
 
-    uint32_t magic;
+    virtual Coin GetReward(size_t height) const;
 
 protected:
     Params() = default;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -53,7 +53,8 @@ public:
     uint32_t deleteForkThreshold;
 
     Coin maxMoney;
-    Coin baseReward;
+    uint64_t baseReward;
+    uint32_t rewardAdjustInterval;
     uint32_t msRewardCoefficient;
 
     float sortitionCoefficient;

--- a/src/consensus/vertex.cpp
+++ b/src/consensus/vertex.cpp
@@ -47,7 +47,7 @@ void Vertex::LinkMilestone(const MilestonePtr& pcs) {
 
 void Vertex::UpdateReward(const Coin& prevReward) {
     // cumulative reward without fee; default for blocks except first registration
-    cumulativeReward = prevReward + GetParams().reward;
+    cumulativeReward = prevReward + GetParams().GetReward(height);
 
     if (cblock->HasTransaction()) {
         if (cblock->IsRegistration()) {
@@ -64,7 +64,8 @@ void Vertex::UpdateMilestoneReward() {
         return;
     }
 
-    cumulativeReward += GetParams().reward * ((snapshot->GetLevelSet().size() - 1) / GetParams().msRewardCoefficient);
+    cumulativeReward +=
+        GetParams().GetReward(height) * ((snapshot->GetLevelSet().size() - 1) / GetParams().msRewardCoefficient);
 }
 
 size_t Vertex::GetNumOfValidTxns() const {

--- a/src/utils/threadpool.cpp
+++ b/src/utils/threadpool.cpp
@@ -32,7 +32,7 @@ void ThreadPool::WorkerThread(uint32_t id) {
         } while (run);
 
     } catch (std::exception& e) {
-        spdlog::error("{} thrown in thread pool", e.what());
+        spdlog::error("\"{}\" thrown in thread pool", e.what());
     }
 }
 

--- a/test/consensus/test_chain_verification.cpp
+++ b/test/consensus/test_chain_verification.cpp
@@ -104,6 +104,8 @@ TEST_F(TestChainVerification, verify_with_redemption_and_reward) {
     std::array<uint256, HEIGHT> hashes;
     std::array<bool, HEIGHT> isRedemption{};
     std::array<bool, HEIGHT> isMilestone{};
+    Coin baseRewardIssued{};
+    Coin baseRewardCalculated{};
     isRedemption.fill(false);
     isMilestone.fill(false);
 
@@ -224,13 +226,14 @@ TEST_F(TestChainVerification, verify_with_redemption_and_reward) {
                 ASSERT_EQ(vtcs[i]->isRedeemed, Vertex::NOT_YET_REDEEMED);
             }
         } else {
+            auto block_reward = GetParams().GetReward(vtcs[i]->height);
             if (i > 0 && !isMilestone[i]) {
-                ASSERT_EQ(vtcs[i]->cumulativeReward, vtcs[i - 1]->cumulativeReward + GetParams().reward);
+                ASSERT_EQ(vtcs[i]->cumulativeReward, vtcs[i - 1]->cumulativeReward + block_reward);
             } else if (i == 0) {
-                ASSERT_EQ(vtcs[i]->cumulativeReward, GetParams().reward);
+                ASSERT_EQ(vtcs[i]->cumulativeReward, block_reward);
             } else {
                 ASSERT_EQ(vtcs[i]->cumulativeReward.GetValue(),
-                          (vtcs[i - 1]->cumulativeReward + GetParams().reward * lvsSizes[i]).GetValue());
+                          (vtcs[i - 1]->cumulativeReward + block_reward * lvsSizes[i]).GetValue());
             }
         }
 

--- a/test/rpc/test_rpc.cpp
+++ b/test/rpc/test_rpc.cpp
@@ -187,7 +187,7 @@ TEST_F(TestRPCServer, basic_dag_info_query) {
     const auto STORED_HEIGHT = HEIGHT - GetParams().punctualityThred;
 
     for (size_t i = 0; i < STORED_HEIGHT; i++) {
-        const auto& hash = chain[i].back()->cblock->GetHash();
+        const auto& hash    = chain[i].back()->cblock->GetHash();
         const auto req_hash = std::to_string(hash);
 
         auto re_size = client->GetLevelSetSize(req_hash); // get level set size


### PR DESCRIPTION
In this PR I implemented our reward adjustment model, that in each epoch n, the basic block reward reduces to 1/n of the base block reward when we first launch the network.