### PR TITLE
Fix the threadpool

### DIFF
--- a/src/net/connection_manager.cpp
+++ b/src/net/connection_manager.cpp
@@ -125,7 +125,7 @@ static void AcceptCallback(evconnlistener_t* listener, evutil_socket_t fd, socka
     bufferevent_enable(bev, EV_READ);
 }
 
-ConnectionManager::ConnectionManager() {
+ConnectionManager::ConnectionManager() : serialize_pool_(1), deserialize_pool_(1) {
     evthread_use_pthreads();
     base_ = event_base_new();
 }
@@ -195,9 +195,7 @@ bool ConnectionManager::Connect(uint32_t ip, uint16_t port) {
 }
 
 void ConnectionManager::Start() {
-    serialize_pool_.SetThreadSize(serialize_pool_size_);
     serialize_pool_.Start();
-    deserialize_pool_.SetThreadSize(deserialize_pool_size_);
     deserialize_pool_.Start();
     /* thread for listen accept event callback and receive message to the queue */
     thread_event_base_ = std::thread(event_base_loop, base_, EVLOOP_NO_EXIT_ON_EMPTY);

--- a/src/net/connection_manager.h
+++ b/src/net/connection_manager.h
@@ -136,10 +136,9 @@ private:
     std::atomic_size_t checksum_error_packages_ = 0;
 
     ThreadPool serialize_pool_;
-    uint32_t serialize_pool_size_ = 1;
 
     ThreadPool deserialize_pool_;
-    uint32_t deserialize_pool_size_ = 1;
+
 
     void WriteOneMessage_(shared_connection_t connection, unique_message_t& message);
 

--- a/src/pow/solver.h
+++ b/src/pow/solver.h
@@ -39,9 +39,7 @@ protected:
 
 class CPUSolver : public Solver {
 public:
-    CPUSolver(size_t nThreads) : Solver() {
-        solverPool_.SetThreadSize(nThreads);
-    }
+    CPUSolver(size_t nThreads) : Solver(), solverPool_(nThreads) {}
 
     ~CPUSolver() override {
         solverPool_.Stop();

--- a/src/remote_solver/epic_solver.cpp
+++ b/src/remote_solver/epic_solver.cpp
@@ -37,9 +37,12 @@ int main(int argc, char* argv[]) {
     cxxopts::Options options("solver server");
     std::string address{};
     uint32_t thread_size{0};
-    options.add_options()("h,help", "print help message", cxxopts::value<bool>())(
-        "addr", "ip address with port", cxxopts::value<std::string>())("size", "max size of threads",
-                                                                       cxxopts::value<uint32_t>());
+    // clang-format off
+    options.add_options()
+    ("h,help", "print help message", cxxopts::value<bool>())
+    ("addr", "ip address with port", cxxopts::value<std::string>())
+    ("size", "max size of threads", cxxopts::value<uint32_t>());
+    // clang-format on
 
     auto parsed_options = options.parse(argc, argv);
     if (parsed_options["help"].as<bool>()) {
@@ -61,6 +64,11 @@ int main(int argc, char* argv[]) {
     spdlog::info("Creating RPC server. IP address = {}", address);
     auto server = std::make_unique<BasicRPCServer>(address);
 
+    int nGPUDevices{};
+    gpuAssert(cudaGetDeviceCount(&nGPUDevices), (char*) __FILE__, __LINE__);
+    spdlog::info("Miner using GPU. Found {} GPU devices.", nGPUDevices);
+
+    thread_size = thread_size < nGPUDevices ? thread_size : nGPUDevices;
     spdlog::info("Creating solver. Thread size = {}", thread_size);
     auto solver = std::make_shared<SolverManager>(thread_size);
 

--- a/src/remote_solver/solver_manager.cpp
+++ b/src/remote_solver/solver_manager.cpp
@@ -14,17 +14,9 @@ inline void SetTimestamp(VStream& vs, uint32_t t) {
     memcpy(vs.data() + vs.size() - 3 * sizeof(uint32_t), &t, sizeof(uint32_t));
 }
 
-SolverManager::SolverManager(size_t nThreads) {
+SolverManager::SolverManager(size_t nThreads) : solverPool_(nThreads) {
     FillDefaultGPUParams(solverParams_);
-    int nGPUDevices{};
-    gpuAssert(cudaGetDeviceCount(&nGPUDevices), (char*) __FILE__, __LINE__);
-    spdlog::info("Miner using GPU. Found {} GPU devices.", nGPUDevices);
-
-    nThreads = std::max(nThreads, (size_t) 1);
-    nThreads = std::min(nThreads, (size_t) nGPUDevices);
-    solverPool_.SetThreadSize(nThreads);
 }
-
 
 bool SolverManager::Start() {
     bool flag = false;

--- a/src/utils/threadpool.cpp
+++ b/src/utils/threadpool.cpp
@@ -14,31 +14,32 @@ void CallableWrapper::operator()() {
     impl->Call();
 }
 
-ThreadPool::ThreadPool(size_t worker_size) {
-    SetThreadSize(worker_size);
+ThreadPool::ThreadPool(size_t worker_size) : size_(worker_size), working_states(worker_size) {
+    workers_.reserve(size_);
 }
 
 void ThreadPool::WorkerThread(uint32_t id) {
+#ifdef NDEBUG
     try {
+#endif
         bool run;
         do {
             CallableWrapper task;
             run = task_queue_.Take(task);
             if (task_queue_enabled_.load() && run) {
-                working_states->at(id) = true;
+                working_states.at(id) = true;
                 task();
-                working_states->at(id) = false;
+                working_states.at(id) = false;
             }
         } while (run);
-
+#ifdef NDEBUG
     } catch (std::exception& e) {
-        spdlog::error("\"{}\" thrown in thread pool", e.what());
+        working_states.at(id) = false;
+        workers_.at(id).detach();
+        workers_.at(id) = std::thread(std::bind(&ThreadPool::WorkerThread, this, id));
+        spdlog::error("\"{}\" thrown in thread pool, restart the thread", e.what());
     }
-}
-
-void ThreadPool::SetThreadSize(size_t size) {
-    size_ = size;
-    workers_.reserve(size_);
+#endif
 }
 
 void ThreadPool::Start() {
@@ -46,9 +47,9 @@ void ThreadPool::Start() {
     task_queue_.Enable();
 
     for (size_t i = 0; i < size_; i++) {
+        working_states.at(i) = false;
         workers_.emplace_back(&ThreadPool::WorkerThread, this, i);
     }
-    working_states = new std::vector<std::atomic_bool>(workers_.size());
 }
 
 void ThreadPool::Stop() {
@@ -60,11 +61,6 @@ void ThreadPool::Stop() {
         }
     }
     workers_.clear();
-
-    if (working_states) {
-        delete working_states;
-        working_states = nullptr;
-    }
     spdlog::debug("ThreadPool stopped.");
 }
 
@@ -81,11 +77,9 @@ bool ThreadPool::IsIdle() const {
         return false;
     }
 
-    if (working_states) {
-        for (const auto& s : *working_states) {
-            if (s.load()) {
-                return false;
-            }
+    for (const auto& s : working_states) {
+        if (s.load()) {
+            return false;
         }
     }
 
@@ -106,8 +100,4 @@ void ThreadPool::Abort() {
         std::this_thread::yield();
     }
     task_queue_enabled_ = true;
-}
-
-ThreadPool::~ThreadPool() {
-    delete working_states;
 }

--- a/src/utils/threadpool.h
+++ b/src/utils/threadpool.h
@@ -51,10 +51,8 @@ class ThreadPool {
 public:
     explicit ThreadPool(size_t worker_size);
 
-    void SetThreadSize(size_t size);
-
-    ThreadPool() = default;
-    ~ThreadPool();
+    ThreadPool()  = delete;
+    ~ThreadPool() = default;
 
     void Start();
 
@@ -107,7 +105,7 @@ private:
     size_t size_;
     BlockingQueue<CallableWrapper> task_queue_;
     std::vector<std::thread> workers_;
-    std::vector<std::atomic_bool>* working_states{};
+    std::vector<std::atomic_bool> working_states;
     std::atomic_bool task_queue_enabled_ = true;
 
     void WorkerThread(uint32_t id);

--- a/test/utils/test_concurrent_containers.cpp
+++ b/test/utils/test_concurrent_containers.cpp
@@ -10,12 +10,11 @@
 
 class TestConcurrentContainers : public testing::Test {
 protected:
-    ThreadPool threadPool;
+    ThreadPool threadPool = ThreadPool(4);
     int testSize;
 
     void SetUp() {
         testSize = 10000;
-        threadPool.SetThreadSize(4);
         threadPool.Start();
     }
 

--- a/test/utils/test_threadpool.cpp
+++ b/test/utils/test_threadpool.cpp
@@ -11,8 +11,7 @@
 
 class TestThreadPool : public testing::Test {
 public:
-    ThreadPool threadPool;
-    size_t threadsize = 3;
+    ThreadPool threadPool = ThreadPool(3);
 
     void f0() {
         spdlog::info("f0 is executed");
@@ -45,7 +44,6 @@ public:
     };
 
     void SetUp() {
-        threadPool.SetThreadSize(threadsize);
         threadPool.Start();
     }
 


### PR DESCRIPTION
1. Fix the coredump when destruct the threadpool which didn't start.
2. Disable the exception catch in debug mode.
3. Restart the dead thread when some exceptions occurred in release mode.